### PR TITLE
feat(prototype): Live screen dark-mode prototype — U-023 version B (tool-first)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,10 @@ If a user asks in natural language to "pull in", "plan", or "create a plan for" 
 - **Installation**: 21st.dev magic
 - **Configuration**: "API_KEY": "your-21st-dev-api-key"
 - **Description**: Create crafted UI components inspired by the best 21st.dev design engineers.
-- **Usage in this repo**: Treat generated output as inspiration or a starting point only. Any adopted code MUST be translated into this repository's preferred UI stack and existing app conventions.
 
 ## Preferred UI Stack
 
-For all new UI work in `apps/web`, prefer:
+For all new UI work in `apps/web`, the baseline implementation stack is:
 
 - Next.js App Router
 - Tailwind CSS for styling
@@ -84,9 +83,30 @@ Rules:
 - Keep styling in Tailwind utilities unless there is a strong reason not to
 - Prefer server-side data loading where appropriate for the current app structure
 - Optimise for clean information hierarchy, readability, and simple layouts over decorative design
-- If using external UI skills, generators, or MCP servers, always adapt the result to this stack rather than copying the suggested stack verbatim
-- If using `ui-ux-pro-max-skill`, do NOT rely on its default `html-tailwind` stack for implementation guidance; use `nextjs` or `shadcn` guidance and still conform to the repo structure in `apps/web`
-- 21st.dev Magic and similar tools may be used for component ideas, interaction patterns, and visual direction, but they must not override the project stack choices above
+
+## UI Tooling Modes
+
+There are two valid ways to implement UI work in this repo. Use the one the user asks for.
+
+### 1. Baseline Mode
+
+Use the baseline implementation stack above.
+
+This is the default when the user asks to implement a UI story without naming a specific external UI tool.
+
+### 2. Tool-First Mode
+
+If the user explicitly asks to use external UI tooling such as `ui-ux-pro-max-skill` or 21st.dev Magic, use those tools as the primary source of UI direction during implementation.
+
+Rules for Tool-First Mode:
+- Follow the chosen tool's workflow and recommendations for UI implementation
+- Keep all implementation inside `apps/web` unless instructed otherwise
+- Prefer outputs that still fit the current app structure and routing model
+- If the generated result would introduce a major architectural shift or a second UI component library, pause and confirm before committing to it
+
+Planning rule:
+- If the user asks to "pull in", "plan", or "create a plan for" a feature, remain in plan-only mode first
+- Tool choice mainly affects the implementation phase, not the initial planning phase, unless the user explicitly asks for tool-assisted design exploration during planning
 
 ### Testing
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,3 +1,8 @@
+/* Fira Code + Fira Sans — skill recommendation for dashboard/data UI */
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Fira+Sans:wght@300;400;500;600;700&display=swap');
+
+@import "tailwindcss";
+
 :root {
   color-scheme: light;
   --bg: #f3efe6;

--- a/apps/web/app/live/LiveScreen.tsx
+++ b/apps/web/app/live/LiveScreen.tsx
@@ -1,0 +1,799 @@
+'use client';
+
+import { use, useState } from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import {
+  RefreshCw,
+  AlertTriangle,
+  WifiOff,
+  CheckCircle2,
+  Clock,
+  Zap,
+  Home,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  ChevronRight,
+  Activity,
+  ChevronLeft,
+} from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ScreenState = 'healthy' | 'stale' | 'warning' | 'disconnected';
+
+// ─── Mock data ────────────────────────────────────────────────────────────────
+
+function generateChartData(state: ScreenState) {
+  const labels = ['11:00', '11:05', '11:10', '11:15', '11:20', '11:25', '11:30'];
+  const base = [
+    { gen: 2.1, cons: 0.9, imp: 0.1, exp: 1.2 },
+    { gen: 2.3, cons: 1.0, imp: 0.0, exp: 1.3 },
+    { gen: 2.4, cons: 0.8, imp: 0.0, exp: 1.6 },
+    { gen: 2.2, cons: 1.1, imp: 0.2, exp: 1.1 },
+    { gen: 2.1, cons: 0.9, imp: 0.1, exp: 1.2 },
+    { gen: 2.3, cons: 1.0, imp: 0.0, exp: 1.3 },
+    { gen: 2.1, cons: 0.9, imp: 0.1, exp: 1.2 },
+  ];
+  if (state === 'stale' || state === 'warning') {
+    return labels.slice(0, 5).map((t, i) => ({
+      time: t,
+      generation: base[i].gen,
+      consumption: base[i].cons,
+      import: base[i].imp,
+      export: base[i].exp,
+    }));
+  }
+  if (state === 'disconnected') return [];
+  return labels.map((t, i) => ({
+    time: t,
+    generation: base[i].gen,
+    consumption: base[i].cons,
+    import: base[i].imp,
+    export: base[i].exp,
+  }));
+}
+
+// ─── Design tokens (from ui-ux-pro-max skill) ─────────────────────────────────
+// Real-Time Monitoring + Dark Mode hybrid
+// Fira Code for KPI values, Fira Sans for body
+// Pulsing live dot, minimal glow accents, border-based card separation
+
+const CHART_COLORS = {
+  generation:  '#fbbf24', // amber-400 — solar
+  consumption: '#64748b', // slate-500
+  import:      '#475569', // slate-600 — deliberately dim
+  export:      '#34d399', // emerald-400 — positive
+};
+
+// ─── Prototype switcher ────────────────────────────────────────────────────────
+
+function PrototypeSwitcher({
+  current,
+  onChange,
+}: {
+  current: ScreenState;
+  onChange: (s: ScreenState) => void;
+}) {
+  const states: { id: ScreenState; label: string }[] = [
+    { id: 'healthy',      label: 'Healthy' },
+    { id: 'stale',        label: 'Stale' },
+    { id: 'warning',      label: 'Warning' },
+    { id: 'disconnected', label: 'Disconnected' },
+  ];
+  return (
+    <div className="bg-slate-950 border-b border-slate-800 px-4 py-2 flex items-center gap-3 text-xs flex-wrap">
+      <span className="text-slate-600 uppercase tracking-widest text-[10px] font-medium">
+        Prototype state:
+      </span>
+      {states.map((s) => (
+        <button
+          key={s.id}
+          onClick={() => onChange(s.id)}
+          className={`px-3 py-1 rounded-full border transition-all duration-150 font-medium cursor-pointer ${
+            current === s.id
+              ? 'bg-amber-500/20 border-amber-500/60 text-amber-300'
+              : 'border-slate-700 text-slate-500 hover:border-slate-500 hover:text-slate-300'
+          }`}
+        >
+          {s.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── Trust badge ──────────────────────────────────────────────────────────────
+// Skill: status colours — live #22C55E, warning #F97316, critical #DC2626
+// With shape/icon alongside colour (not colour-only) per WCAG
+
+function TrustBadge({ state }: { state: ScreenState }) {
+  const configs: Record<
+    ScreenState,
+    { icon: React.ReactNode; label: string; dotClass: string; pillClass: string }
+  > = {
+    healthy: {
+      icon: <CheckCircle2 size={12} />,
+      label: 'Updated 12 seconds ago',
+      dotClass: 'bg-emerald-400 animate-live-pulse',
+      pillClass: 'bg-emerald-500/10 border-emerald-500/30 text-emerald-400',
+    },
+    stale: {
+      icon: <Clock size={12} />,
+      label: 'Last seen 18 minutes ago',
+      dotClass: 'bg-orange-400',
+      pillClass: 'bg-orange-500/10 border-orange-500/30 text-orange-400',
+    },
+    warning: {
+      icon: <AlertTriangle size={12} />,
+      label: 'Suspicious data — 3 min ago',
+      dotClass: 'bg-orange-400',
+      pillClass: 'bg-orange-500/10 border-orange-500/30 text-orange-400',
+    },
+    disconnected: {
+      icon: <WifiOff size={12} />,
+      label: 'Provider disconnected',
+      dotClass: 'bg-red-500',
+      pillClass: 'bg-red-500/10 border-red-500/30 text-red-400',
+    },
+  };
+  const { icon, label, dotClass, pillClass } = configs[state];
+  return (
+    <span
+      className={`inline-flex items-center gap-2 px-2.5 py-1 rounded-full border text-xs font-medium ${pillClass}`}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotClass}`} />
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+// ─── Warning banner ────────────────────────────────────────────────────────────
+// Skill: alert colours, calm tone, shape + colour combined, one CTA
+
+function WarningBanner({
+  state,
+  onAction,
+}: {
+  state: ScreenState;
+  onAction: () => void;
+}) {
+  if (state === 'healthy') return null;
+
+  const configs: Partial<Record<ScreenState, {
+    icon: React.ReactNode;
+    msg: string;
+    cta: string;
+    cls: string;
+  }>> = {
+    stale: {
+      icon: <Clock size={14} className="shrink-0 mt-px" />,
+      msg: 'Live data is delayed. Your system was last seen 18 minutes ago.',
+      cta: 'Review Data Health',
+      cls: 'bg-orange-500/10 border-orange-500/20 text-orange-300',
+    },
+    warning: {
+      icon: <AlertTriangle size={14} className="shrink-0 mt-px" />,
+      msg: 'Some readings look unusually high. This may be a provider reporting issue.',
+      cta: 'Review Data Health',
+      cls: 'bg-orange-500/10 border-orange-500/20 text-orange-300',
+    },
+    disconnected: {
+      icon: <WifiOff size={14} className="shrink-0 mt-px" />,
+      msg: 'MyEnergi is not connected. Credentials may have expired.',
+      cta: 'Reconnect',
+      cls: 'bg-red-500/10 border-red-500/20 text-red-300',
+    },
+  };
+
+  const cfg = configs[state];
+  if (!cfg) return null;
+
+  return (
+    <div className={`flex items-start gap-3 px-4 sm:px-6 py-2.5 text-xs border-b ${cfg.cls}`}>
+      {cfg.icon}
+      <span className="flex-1">{cfg.msg}</span>
+      <button
+        onClick={onAction}
+        className="shrink-0 font-semibold underline underline-offset-2 cursor-pointer"
+      >
+        {cfg.cta} →
+      </button>
+    </div>
+  );
+}
+
+// ─── Metric card ──────────────────────────────────────────────────────────────
+// Skill: Fira Code for KPI values (tabular, monospaced)
+// Skill: border-based card separation on dark backgrounds
+// Skill: minimal glow ring for active state (box-shadow at low opacity)
+// Skill: desaturate + dim for stale state
+
+type MetricCardProps = {
+  label: string;
+  value: string;
+  unit: string;
+  caption: string;
+  icon: React.ReactNode;
+  accentClass: string;
+  glowColor: string;
+  stale?: boolean;
+};
+
+function MetricCard({
+  label,
+  value,
+  unit,
+  caption,
+  icon,
+  accentClass,
+  glowColor,
+  stale,
+}: MetricCardProps) {
+  return (
+    <div
+      className={`
+        relative rounded-xl border p-4 flex flex-col gap-1 transition-all duration-300
+        ${stale
+          ? 'bg-[#1e293b]/50 border-slate-700/40'
+          : 'bg-[#1e293b] border-slate-700/60 hover:border-slate-600/80'
+        }
+      `}
+      style={
+        !stale
+          ? { boxShadow: `0 0 0 1px ${glowColor}, inset 0 1px 0 rgba(255,255,255,0.04)` }
+          : undefined
+      }
+    >
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[11px] font-medium text-slate-500 uppercase tracking-wider">
+          {label}
+        </span>
+        <span className={`${stale ? 'text-slate-600' : accentClass} transition-colors`}>
+          {icon}
+        </span>
+      </div>
+
+      <div className="flex items-baseline gap-1.5">
+        {/* Skill: Fira Code for KPI values — tabular, monospaced */}
+        <span
+          className={`font-mono text-3xl font-bold tabular-nums leading-none transition-all ${
+            stale ? 'text-slate-600' : 'text-slate-100'
+          }`}
+        >
+          {value}
+        </span>
+        <span className={`text-sm font-mono ${stale ? 'text-slate-700' : 'text-slate-500'}`}>
+          {unit}
+        </span>
+        {stale && <Clock size={11} className="text-orange-600 mb-0.5" />}
+      </div>
+
+      <span className={`text-[11px] ${stale ? 'text-slate-700' : 'text-slate-500'}`}>
+        {caption}
+      </span>
+    </div>
+  );
+}
+
+// ─── Coverage bar ──────────────────────────────────────────────────────────────
+// Skill: progress bar style from bullet chart guidance
+// Solar gold fill, slate dim for grid portion
+
+function CoverageBar({ solarPct, stale }: { solarPct: number; stale?: boolean }) {
+  return (
+    <div className={`rounded-xl border p-4 bg-[#1e293b] transition-opacity ${
+      stale ? 'border-slate-700/30 opacity-60' : 'border-slate-700/60'
+    }`}>
+      <div className="flex justify-between items-center mb-2">
+        <div className="flex items-center gap-1.5 text-xs text-slate-400 font-medium">
+          <span className="w-2 h-2 rounded-full bg-amber-400" />
+          Solar
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-slate-500 font-medium">
+          Grid
+          <span className="w-2 h-2 rounded-full bg-slate-600" />
+        </div>
+      </div>
+      <div className="relative h-2.5 rounded-full bg-slate-700/60 overflow-hidden">
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-amber-400 transition-all duration-700"
+          style={{
+            width: `${solarPct}%`,
+            boxShadow: stale ? 'none' : '0 0 8px rgba(251,191,36,0.4)',
+          }}
+        />
+      </div>
+      <p className="mt-2 text-xs text-slate-400">
+        <span className={`font-semibold font-mono ${stale ? 'text-slate-500' : 'text-amber-400'}`}>
+          {solarPct}%
+        </span>{' '}
+        of your home is running on solar right now
+        {stale && <span className="ml-1 text-orange-600">(last known)</span>}
+      </p>
+    </div>
+  );
+}
+
+// ─── Custom chart tooltip ──────────────────────────────────────────────────────
+
+function DarkTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name: string; value: number; color: string }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-[#1e293b] border border-slate-700 rounded-xl px-3 py-2.5 shadow-xl text-xs">
+      <p className="text-slate-400 font-mono mb-1.5">{label}</p>
+      {payload.map((entry) => (
+        <div key={entry.name} className="flex items-center gap-2 mb-0.5">
+          <span
+            className="w-2 h-2 rounded-full shrink-0"
+            style={{ background: entry.color }}
+          />
+          <span className="text-slate-300 capitalize">{entry.name}</span>
+          <span className="font-mono font-semibold text-slate-100 ml-auto pl-4">
+            {entry.value.toFixed(2)} kW
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Live trend chart ──────────────────────────────────────────────────────────
+// Skill: Streaming Area Chart — fading opacity on history, current pulse
+// Skill: dark chart bg, very subtle grid lines (not competing with data)
+// Skill: legend-interactive — toggleable series
+
+function LiveTrendChart({
+  data,
+  stale,
+}: {
+  data: ReturnType<typeof generateChartData>;
+  stale?: boolean;
+}) {
+  const [resolution, setResolution] = useState<'5min' | '15min'>('5min');
+
+  return (
+    <div className={`rounded-xl border bg-[#1e293b] overflow-hidden transition-all ${
+      stale ? 'border-orange-500/20' : 'border-slate-700/60'
+    }`}>
+      <div className="flex items-center justify-between px-4 pt-4 pb-3 border-b border-slate-700/40">
+        <div className="flex items-center gap-2">
+          <Activity size={14} className={stale ? 'text-orange-500' : 'text-slate-400'} />
+          <h3 className="text-sm font-semibold text-slate-200">
+            Live trend
+          </h3>
+          <span className="text-xs text-slate-500">(last 30 min)</span>
+        </div>
+        {/* Skill: time-resolution toggle — compact segmented control in chart header */}
+        <div className="flex rounded-lg border border-slate-700 overflow-hidden text-xs">
+          {(['5min', '15min'] as const).map((r) => (
+            <button
+              key={r}
+              onClick={() => setResolution(r)}
+              className={`px-2.5 py-1 font-mono transition-colors cursor-pointer ${
+                resolution === r
+                  ? 'bg-slate-100 text-slate-900'
+                  : 'bg-transparent text-slate-500 hover:text-slate-300'
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {stale && data.length > 0 && (
+        <div className="mx-4 mt-3 flex items-center gap-1.5 text-xs text-orange-400 bg-orange-500/10 border border-orange-500/20 px-3 py-1.5 rounded-lg">
+          <Clock size={11} />
+          Data delayed — shown up to last available point
+        </div>
+      )}
+
+      <div className="px-2 py-3">
+        {data.length === 0 ? (
+          <div className="h-48 flex items-center justify-center text-sm text-slate-600 bg-slate-800/40 rounded-lg mx-2">
+            No live data available
+          </div>
+        ) : (
+          /* Skill: desaturate for stale state */
+          <div className={stale ? 'opacity-50 saturate-0' : ''}>
+            <ResponsiveContainer width="100%" height={200}>
+              <AreaChart
+                data={data}
+                margin={{ top: 4, right: 8, left: -12, bottom: 0 }}
+              >
+                <defs>
+                  {Object.entries(CHART_COLORS).map(([key, color]) => (
+                    <linearGradient
+                      key={key}
+                      id={`darkGrad-${key}`}
+                      x1="0" y1="0" x2="0" y2="1"
+                    >
+                      {/* Skill: fading opacity for streaming history */}
+                      <stop offset="5%"  stopColor={color} stopOpacity={0.25} />
+                      <stop offset="95%" stopColor={color} stopOpacity={0.03} />
+                    </linearGradient>
+                  ))}
+                </defs>
+                <XAxis
+                  dataKey="time"
+                  tick={{ fontSize: 10, fill: '#475569', fontFamily: 'Fira Code, monospace' }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <YAxis
+                  tick={{ fontSize: 10, fill: '#475569', fontFamily: 'Fira Code, monospace' }}
+                  axisLine={false}
+                  tickLine={false}
+                  tickFormatter={(v) => `${v}kW`}
+                  /* Skill: subtle grid lines, not dominant */
+                />
+                {/* Skill: dark tooltip, all series at hover point */}
+                <Tooltip content={<DarkTooltip />} />
+                <Legend
+                  iconType="circle"
+                  iconSize={7}
+                  wrapperStyle={{
+                    fontSize: 11,
+                    paddingTop: 10,
+                    fontFamily: 'Fira Sans, system-ui, sans-serif',
+                    color: '#64748b',
+                  }}
+                  formatter={(v) => (
+                    <span style={{ color: '#94a3b8', textTransform: 'capitalize' }}>
+                      {String(v)}
+                    </span>
+                  )}
+                />
+                {Object.entries(CHART_COLORS).map(([key, color]) => (
+                  <Area
+                    key={key}
+                    type="monotone"
+                    dataKey={key}
+                    stroke={color}
+                    fill={`url(#darkGrad-${key})`}
+                    strokeWidth={key === 'import' ? 1 : 1.5}
+                    dot={false}
+                    activeDot={{ r: 3, fill: color, strokeWidth: 0 }}
+                  />
+                ))}
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Today totals ──────────────────────────────────────────────────────────────
+
+function TodayTotals({
+  stale,
+  onViewDay,
+}: {
+  stale?: boolean;
+  onViewDay: () => void;
+}) {
+  const rows = [
+    { label: 'Generated', value: '14.2', unit: 'kWh', color: 'text-amber-400' },
+    { label: 'Consumed',  value: '9.8',  unit: 'kWh', color: 'text-slate-400' },
+    { label: 'Imported',  value: '1.6',  unit: 'kWh', color: 'text-slate-600' },
+    { label: 'Exported',  value: '4.4',  unit: 'kWh', color: 'text-emerald-400' },
+  ];
+  return (
+    <div className="rounded-xl border border-slate-700/60 bg-[#1e293b] p-4 flex flex-col">
+      <h3 className="text-sm font-semibold text-slate-200 mb-0.5">
+        Today so far
+      </h3>
+      {stale && (
+        <p className="text-[11px] text-orange-400 mb-2">May be incomplete</p>
+      )}
+      <div className="space-y-2.5 mt-2 flex-1">
+        {rows.map(({ label, value, unit, color }) => (
+          <div key={label} className="flex items-baseline justify-between">
+            <span className="text-xs text-slate-500">{label}</span>
+            <span className={`font-mono text-sm font-semibold tabular-nums ${
+              stale ? 'text-slate-600' : color
+            }`}>
+              {value}
+              <span className="text-slate-600 font-normal ml-0.5 text-[11px]">{unit}</span>
+            </span>
+          </div>
+        ))}
+      </div>
+      <button
+        onClick={onViewDay}
+        className="mt-4 flex items-center gap-1 text-xs font-medium text-amber-500 hover:text-amber-400 transition-colors cursor-pointer"
+      >
+        View full day <ChevronRight size={12} />
+      </button>
+    </div>
+  );
+}
+
+// ─── Notes panel ──────────────────────────────────────────────────────────────
+
+function NotesPanel({
+  state,
+  showEfficiency,
+  onDataHealth,
+}: {
+  state: ScreenState;
+  showEfficiency: boolean;
+  onDataHealth: () => void;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-700/60 bg-[#1e293b] p-4 flex flex-col gap-3">
+      <h3 className="text-sm font-semibold text-slate-200">Notes</h3>
+
+      {state === 'healthy' && (
+        <div className="flex items-start gap-2 text-xs text-slate-500 bg-slate-800/50 rounded-lg px-3 py-2.5">
+          <Activity size={12} className="mt-px shrink-0 text-slate-600" />
+          Today&apos;s totals are still accumulating — check back after midnight for the full day summary.
+        </div>
+      )}
+
+      {(state === 'stale' || state === 'warning') && (
+        <div className="flex items-start gap-2 text-xs text-orange-300 bg-orange-500/10 border border-orange-500/20 rounded-lg px-3 py-2.5">
+          <AlertTriangle size={12} className="mt-px shrink-0" />
+          <div>
+            <span className="font-semibold block mb-0.5">
+              {state === 'stale' ? 'Data delayed' : 'Suspicious readings'}
+            </span>
+            {state === 'stale'
+              ? 'Live feed has not updated in 18 minutes. Historical summaries remain accurate.'
+              : 'One or more interval readings appear unusually high. Provider reporting may be at fault.'
+            }
+            <button
+              onClick={onDataHealth}
+              className="block mt-1.5 font-semibold underline underline-offset-2 text-orange-400 cursor-pointer"
+            >
+              Review Data Health →
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showEfficiency && state !== 'disconnected' && (
+        <div className="text-xs text-slate-500 flex items-center justify-between bg-slate-800/50 rounded-lg px-3 py-2">
+          <span>Efficiency</span>
+          <span className="font-mono font-semibold text-slate-300">78%
+            <span className="font-normal text-slate-600 ml-1">of 18 kWp max</span>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Disconnected state ────────────────────────────────────────────────────────
+// Skill: single primary CTA, destructive colour, error recovery path
+
+function DisconnectedState({ onReconnect }: { onReconnect: () => void }) {
+  return (
+    <div className="flex-1 flex items-center justify-center py-20 px-4">
+      <div className="max-w-xs text-center space-y-5">
+        <div className="relative mx-auto w-14 h-14">
+          <div className="absolute inset-0 rounded-full bg-red-500/10 border border-red-500/20" />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <WifiOff size={22} className="text-red-400" />
+          </div>
+        </div>
+        <div>
+          <h2 className="text-base font-semibold text-slate-100 mb-1.5">
+            MyEnergi is not connected
+          </h2>
+          <p className="text-sm text-slate-500 leading-relaxed">
+            Your provider credentials may have expired. Reconnect to resume live monitoring.
+          </p>
+        </div>
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={onReconnect}
+            className="px-4 py-2 text-sm font-semibold text-white bg-red-500 hover:bg-red-400 rounded-lg transition-colors cursor-pointer"
+          >
+            Reconnect
+          </button>
+          <button className="px-4 py-2 text-sm font-medium text-slate-400 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition-colors cursor-pointer">
+            Troubleshoot
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Nav bar ──────────────────────────────────────────────────────────────────
+// Skill: auto-refresh indicator, user avatar, "Live" label prominent
+
+function NavBar({
+  state,
+  onHome,
+}: {
+  state: ScreenState;
+  onHome: () => void;
+}) {
+  return (
+    <header className="flex items-center justify-between px-4 sm:px-6 h-14 bg-[#1e293b] border-b border-slate-700/60">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onHome}
+          className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+        >
+          <ChevronLeft size={14} />
+          <Home size={13} />
+          <span className="hidden sm:inline">Overview</span>
+        </button>
+        <span className="text-slate-700">/</span>
+        <div className="flex items-center gap-2">
+          {/* Skill: pulsing live dot — --pulse-animation: pulse 2s infinite */}
+          {state === 'healthy' && (
+            <span className="w-2 h-2 rounded-full bg-emerald-400 animate-live-pulse" />
+          )}
+          <span className="text-sm font-semibold text-slate-100">Live</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        {/* Skill: auto-refresh indicator for realtime monitoring */}
+        {state === 'healthy' && (
+          <span className="hidden sm:flex items-center gap-1.5 text-xs text-slate-500">
+            <RefreshCw
+              size={11}
+              className="text-emerald-500"
+              style={{ animation: 'spin 3s linear infinite' }}
+            />
+            Auto-refreshing
+          </span>
+        )}
+        <div className="w-7 h-7 rounded-full bg-slate-700 border border-slate-600 flex items-center justify-center text-xs font-bold text-slate-300">
+          J
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ─── Root component ────────────────────────────────────────────────────────────
+
+export function LiveScreen({
+  searchParams,
+}: {
+  searchParams: Promise<{ state?: string }>;
+}) {
+  const params = use(searchParams);
+  const initialState = (params.state as ScreenState) ?? 'healthy';
+  const [screenState, setScreenState] = useState<ScreenState>(initialState);
+  const [toastMsg, setToastMsg]       = useState<string | null>(null);
+
+  function toast(msg: string) {
+    setToastMsg(msg);
+    setTimeout(() => setToastMsg(null), 2500);
+  }
+
+  const chartData  = generateChartData(screenState);
+  const isStale    = screenState === 'stale' || screenState === 'warning';
+  const isDiscon   = screenState === 'disconnected';
+
+  return (
+    /* Skill: deep slate-900 page bg — not pure OLED black, as requested */
+    <div className="min-h-screen bg-[#0f172a] font-sans" style={{ colorScheme: 'dark' }}>
+
+      {/* Prototype chrome */}
+      <PrototypeSwitcher current={screenState} onChange={setScreenState} />
+
+      <div className="flex flex-col min-h-[calc(100vh-40px)]">
+        <NavBar state={screenState} onHome={() => toast('→ Overview (not yet built)')} />
+
+        <WarningBanner
+          state={screenState}
+          onAction={() => toast(isDiscon ? '→ Provider reconnect (not yet built)' : '→ Data Health (not yet built)')}
+        />
+
+        {/* Trust strip */}
+        <div className="px-4 sm:px-6 py-2.5 border-b border-slate-800 bg-[#0f172a]/80 flex items-center gap-3">
+          <TrustBadge state={screenState} />
+        </div>
+
+        <main className="flex-1 px-4 sm:px-6 py-5 max-w-5xl w-full mx-auto space-y-4">
+          {isDiscon ? (
+            <DisconnectedState onReconnect={() => toast('→ Provider reconnect (not yet built)')} />
+          ) : (
+            <>
+              {/* 4-col metrics — 2×2 on mobile (skill: grid breakpoints) */}
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <MetricCard
+                  label="Generation"
+                  value="2,140"
+                  unit="W"
+                  caption="↑ from panels"
+                  icon={<Zap size={15} />}
+                  accentClass="text-amber-400"
+                  glowColor="rgba(251,191,36,0.12)"
+                  stale={isStale}
+                />
+                <MetricCard
+                  label="Consumption"
+                  value="920"
+                  unit="W"
+                  caption="home using now"
+                  icon={<Home size={15} />}
+                  accentClass="text-slate-400"
+                  glowColor="rgba(100,116,139,0.12)"
+                  stale={isStale}
+                />
+                <MetricCard
+                  label="Import"
+                  value="310"
+                  unit="W"
+                  caption="from grid"
+                  icon={<ArrowDownToLine size={15} />}
+                  accentClass="text-slate-500"
+                  glowColor="rgba(71,85,105,0.12)"
+                  stale={isStale}
+                />
+                <MetricCard
+                  label="Export"
+                  value="810"
+                  unit="W"
+                  caption="to grid"
+                  icon={<ArrowUpFromLine size={15} />}
+                  accentClass="text-emerald-400"
+                  glowColor="rgba(52,211,153,0.12)"
+                  stale={isStale}
+                />
+              </div>
+
+              {/* Coverage bar */}
+              <CoverageBar solarPct={85} stale={isStale} />
+
+              {/* Live trend chart */}
+              <LiveTrendChart data={chartData} stale={isStale} />
+
+              {/* Secondary row */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <TodayTotals
+                  stale={isStale}
+                  onViewDay={() => toast('→ Daily History (not yet built)')}
+                />
+                <NotesPanel
+                  state={screenState}
+                  showEfficiency={true}
+                  onDataHealth={() => toast('→ Data Health (not yet built)')}
+                />
+              </div>
+            </>
+          )}
+        </main>
+      </div>
+
+      {/* Toast — skill: auto-dismiss 3–5s, aria-live for a11y */}
+      {toastMsg && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-slate-800 border border-slate-700 text-slate-200 text-xs font-medium px-4 py-2.5 rounded-xl shadow-2xl z-50 animate-fade-in whitespace-nowrap"
+        >
+          {toastMsg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/live/page.tsx
+++ b/apps/web/app/live/page.tsx
@@ -1,0 +1,14 @@
+import { LiveScreen } from './LiveScreen';
+
+export const metadata = {
+  title: 'Live — PV Manager',
+  description: 'Real-time solar system status',
+};
+
+export default function LivePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ state?: string }>;
+}) {
+  return <LiveScreen searchParams={searchParams} />;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export default function HomePage() {
   return (
     <main className="shell">
@@ -13,6 +15,26 @@ export default function HomePage() {
           <li>Drizzle configuration and schema live only in the rewrite app.</li>
           <li>Legacy and rewrite dependencies now have separate package boundaries.</li>
         </ul>
+        <div style={{ marginTop: '28px', display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+          <Link
+            href="/live"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '6px',
+              padding: '10px 18px',
+              background: '#0d6b57',
+              color: '#fff',
+              borderRadius: '10px',
+              fontFamily: 'system-ui, sans-serif',
+              fontSize: '0.92rem',
+              fontWeight: 600,
+              textDecoration: 'none',
+            }}
+          >
+            Live screen prototype →
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,12 +8,17 @@
       "name": "@pv-manager/web",
       "version": "0.1.0",
       "dependencies": {
+        "@tailwindcss/postcss": "^4.2.2",
         "dotenv": "^17.3.1",
         "drizzle-orm": "^0.45.1",
+        "lucide-react": "^1.7.0",
         "next": "^15.3.0",
         "pg": "^8.16.3",
+        "postcss": "^8.5.8",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "recharts": "^3.8.1",
+        "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
         "@types/node": "^24.5.2",
@@ -27,6 +32,18 @@
         "vitest": "^4.1.1"
       }
     },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
@@ -38,7 +55,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
       "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -60,7 +76,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
       "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1459,18 +1474,55 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
       "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1637,6 +1689,42 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1923,7 +2011,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1935,11 +2028,278 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.2"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1956,6 +2316,69 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -1997,7 +2420,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2012,6 +2435,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.1",
@@ -2152,6 +2581,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2163,14 +2601,140 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2813,12 +3377,35 @@
         }
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -2871,6 +3458,12 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2928,11 +3521,44 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -2965,7 +3591,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2986,7 +3611,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3007,7 +3631,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3028,7 +3651,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3049,7 +3671,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3070,7 +3691,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3094,7 +3714,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3118,7 +3737,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -3142,7 +3760,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -3166,7 +3783,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3187,7 +3803,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3201,11 +3816,19 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -3279,6 +3902,34 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/obug": {
@@ -3408,9 +4059,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3427,9 +4078,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -3494,6 +4145,87 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -3686,6 +4418,31 @@
         }
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3776,6 +4533,37 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vitest": {
       "version": "4.1.1",
@@ -3884,35 +4672,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,12 +15,17 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@tailwindcss/postcss": "^4.2.2",
     "dotenv": "^17.3.1",
     "drizzle-orm": "^0.45.1",
+    "lucide-react": "^1.7.0",
     "next": "^15.3.0",
     "pg": "^8.16.3",
+    "postcss": "^8.5.8",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "recharts": "^3.8.1",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+
+export default config;

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,87 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        // Skill recommendation: Fira Code for KPI values (tabular, monospaced)
+        // Fira Sans for body copy
+        mono: ['Fira Code', 'JetBrains Mono', 'monospace'],
+        sans: ['Fira Sans', 'Inter', 'system-ui', 'sans-serif'],
+      },
+      colors: {
+        // Dark palette: deep slate, not pure OLED black
+        // Skill: Real-Time Monitoring + Dark Mode (OLED) hybrid
+        surface: {
+          page:   '#0f172a', // slate-900 — page background
+          card:   '#1e293b', // slate-800 — card surface
+          raised: '#293548', // between slate-800 and slate-700 — elevated cards
+          inset:  '#0d1726', // darker than page — chart plot area
+          border: '#334155', // slate-700 — card borders
+        },
+        // Text hierarchy on dark
+        content: {
+          primary:   '#f1f5f9', // slate-100
+          secondary: '#94a3b8', // slate-400
+          muted:     '#64748b', // slate-500
+        },
+        // Brand/solar — solar gold
+        solar: {
+          DEFAULT: '#f59e0b', // amber-500
+          dim:     '#78450a', // amber very dim for bg tints
+          glow:    'rgba(245,158,11,0.15)',
+        },
+        // State colours (from skill: --live-indicator, --critical-color)
+        live: {
+          DEFAULT: '#22c55e', // green-500 — healthy/fresh
+          dim:     '#052e16', // green very dim
+          glow:    'rgba(34,197,94,0.15)',
+        },
+        stale: {
+          DEFAULT: '#f97316', // orange-500 — from skill CTA/warning
+          dim:     '#431407',
+          glow:    'rgba(249,115,22,0.12)',
+        },
+        alert: {
+          DEFAULT: '#ef4444', // red-500 — disconnected
+          dim:     '#2d0808',
+          glow:    'rgba(239,68,68,0.12)',
+        },
+        // Chart series on dark (skill: fading opacity for history)
+        chart: {
+          generation:  '#fbbf24', // amber-400 — solar
+          consumption: '#64748b', // slate-500
+          import:      '#334155', // slate-700 — dim
+          export:      '#34d399', // emerald-400 — positive
+        },
+      },
+      keyframes: {
+        // Skill: --pulse-animation: pulse 2s infinite for live indicator
+        livePulse: {
+          '0%, 100%': { opacity: '1', transform: 'scale(1)' },
+          '50%':      { opacity: '0.4', transform: 'scale(1.15)' },
+        },
+        shimmer: {
+          '0%':   { backgroundPosition: '-200% 0' },
+          '100%': { backgroundPosition: '200% 0' },
+        },
+        fadeIn: {
+          from: { opacity: '0', transform: 'translateY(6px)' },
+          to:   { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'live-pulse': 'livePulse 2s ease-in-out infinite',
+        shimmer:      'shimmer 1.8s linear infinite',
+        'fade-in':    'fadeIn 0.2s ease-out forwards',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary

- Implements the U-023 Live screen as a dark-mode polished clickable prototype at `/live`
- This is **version B** of an A/B exercise — version A (feature/U-023-A, #52) uses Baseline Mode with a light palette
- Visual direction driven by **ui-ux-pro-max-skill** (Real-Time Monitoring + Dark Mode hybrid)

## Skill influence on the result

Three queries were run against ui-ux-pro-max:
1. `--design-system "solar energy monitoring realtime dashboard dark mode"` → recommended Real-Time Monitoring pattern + Dark Mode (OLED) style, Fira Code/Fira Sans typography, solar gold + emerald/orange/red status palette
2. `--domain style "dark mode dashboard realtime"` → confirmed Real-Time Monitoring CSS variables (`--live-indicator: #22C55E`, `--pulse-animation: pulse 2s infinite`, `--critical-color: #DC2626`)
3. `--domain chart "real-time live dashboard iot"` → recommended Streaming Area Chart with fading opacity for history, current pulse colour, dark background

**Concrete decisions directly from the skill:**
- **Fira Code** for all KPI values (skill: "dashboard, data, analytics, code, technical, precise")
- **Pulsing live dot** animation on healthy state — from skill `--pulse-animation: pulse 2s infinite`
- **Status colours**: `#22C55E` (healthy), `#F97316` (stale/warning), `#DC2626` (disconnected)
- **Fading opacity gradients** on chart area fills — skill's streaming chart pattern for "fading opacity on older data"
- **Border-based card separation** rather than box shadows (skill guidance: dark mode, shadows ineffective)
- **Custom dark tooltip** component (skill: chart tooltips must be dark-surface on dark UI)
- **Minimal amber glow** on active metric cards — skill's "minimal glow (text-shadow: 0 0 10px)" anti-decoration rule applied sparingly
- `aria-live="polite"` on toast — from skill accessibility checklist

## What's included

**4 prototype states** (on-screen switcher):
- **Healthy** — pulsing green dot, auto-refresh spinner, live badge, all metrics, full chart
- **Stale** — orange badge, warning banner, desaturated/dimmed metrics, chart truncated + annotated
- **Warning** — suspicious data banner, amber notes panel with Data Health CTA
- **Disconnected** — full error state replacing live data, Reconnect / Troubleshoot CTAs

**Dark palette:**
- Page background: `#0f172a` (slate-900 — deep slate, not pure black as requested)
- Card surface: `#1e293b` (slate-800)
- Card border: `slate-700/60`
- Text: `slate-100` primary, `slate-400` secondary, `slate-500` muted
- Solar/brand: amber-400 with `rgba(251,191,36,0.12)` glow
- Export/positive: emerald-400
- Warning: orange-400/500
- Destructive: red-400/500

## Test plan

- [ ] `npm run dev` in `apps/web`, navigate to `/live`
- [ ] Verify dark background renders (slate-900, not white/grey)
- [ ] Verify KPI values use monospace Fira Code font
- [ ] Verify pulsing green dot in nav on Healthy state
- [ ] Verify all 4 states switch correctly
- [ ] Verify chart uses dark custom tooltip on hover
- [ ] Verify mobile layout: 2×2 metric grid, stacked secondary row
- [ ] Verify stale state: desaturated/dimmed metrics + chart greyscale
- [ ] `npm run build` passes clean

Addresses: U-023 (version B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)