### PR TITLE
feat: tighten live screen data health handling

### DIFF
--- a/apps/web/app/live/LiveScreen.tsx
+++ b/apps/web/app/live/LiveScreen.tsx
@@ -209,6 +209,22 @@ function getDismissalStorageKey(date: string, timezone: string): string {
   return `pv-manager:live-warning-dismissals:${timezone}:${date}`;
 }
 
+function getChartPrefsStorageKey(timezone: string): string {
+  return `pv-manager:live-chart-prefs:${timezone}`;
+}
+
+function isResolution(value: string): value is Resolution {
+  return value === '1min' || value === '30min' || value === '1hour';
+}
+
+function isViewMode(value: string): value is ViewMode {
+  return value === 'line' || value === 'cumulative';
+}
+
+function isSeriesKey(value: string): value is SeriesKey {
+  return SERIES_ORDER.includes(value as SeriesKey);
+}
+
 function applyCostViewMode(data: CostPoint[], viewMode: ViewMode): CostPoint[] {
   if (viewMode === 'line') return data;
 
@@ -1112,20 +1128,20 @@ function LiveTrendChart({
             <button
               key={series}
               onClick={() => onToggleSeries(series)}
-              className={`flex items-center justify-between rounded-2xl border px-3 py-2 text-left text-xs transition-colors ${
+              className={`flex min-w-0 items-center justify-between gap-2 rounded-xl border px-2.5 py-2 text-left text-[11px] leading-none transition-colors ${
                 active
                   ? 'border-slate-600 bg-slate-900/70 text-slate-100'
                   : 'border-slate-800 bg-slate-950/60 text-slate-500'
               }`}
             >
-              <span className="flex items-center gap-2">
+              <span className="flex min-w-0 items-center gap-1.5 whitespace-nowrap">
                 <span
-                  className="h-2.5 w-2.5 rounded-full"
+                  className="h-2 w-2 shrink-0 rounded-full"
                   style={{ backgroundColor: SERIES_COLORS[series] }}
                 />
-                {formatSeriesLabel(series)}
+                <span className="truncate">{formatSeriesLabel(series)}</span>
               </span>
-              <span className="text-[11px] text-slate-400">
+              <span className="shrink-0 text-[10px] text-slate-400">
                 {active ? <Eye size={13} /> : <EyeOff size={13} />}
               </span>
             </button>
@@ -1688,9 +1704,43 @@ export function LiveScreen({
 }: LiveScreenProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const [resolution, setResolution] = useState<Resolution>('1min');
-  const [viewMode, setViewMode] = useState<ViewMode>('line');
-  const [activeSeries, setActiveSeries] = useState<SeriesKey[]>(MINUTE_DEFAULT_SERIES);
+  const chartPrefsStorageKey = useMemo(() => getChartPrefsStorageKey(timezone), [timezone]);
+  const [resolution, setResolution] = useState<Resolution>(() => {
+    if (typeof window === 'undefined') return '1min';
+    try {
+      const raw = window.localStorage.getItem(getChartPrefsStorageKey(timezone));
+      if (!raw) return '1min';
+      const parsed = JSON.parse(raw);
+      return isResolution(parsed?.resolution) ? parsed.resolution : '1min';
+    } catch {
+      return '1min';
+    }
+  });
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    if (typeof window === 'undefined') return 'line';
+    try {
+      const raw = window.localStorage.getItem(getChartPrefsStorageKey(timezone));
+      if (!raw) return 'line';
+      const parsed = JSON.parse(raw);
+      return isViewMode(parsed?.viewMode) ? parsed.viewMode : 'line';
+    } catch {
+      return 'line';
+    }
+  });
+  const [activeSeries, setActiveSeries] = useState<SeriesKey[]>(() => {
+    if (typeof window === 'undefined') return MINUTE_DEFAULT_SERIES;
+    try {
+      const raw = window.localStorage.getItem(getChartPrefsStorageKey(timezone));
+      if (!raw) return MINUTE_DEFAULT_SERIES;
+      const parsed = JSON.parse(raw);
+      const series = Array.isArray(parsed?.activeSeries)
+        ? parsed.activeSeries.filter((value: string) => isSeriesKey(value))
+        : [];
+      return series.length > 0 ? series : MINUTE_DEFAULT_SERIES;
+    } catch {
+      return MINUTE_DEFAULT_SERIES;
+    }
+  });
   const [warningDetailsOpen, setWarningDetailsOpen] = useState(false);
   const [selectedIncidentId, setSelectedIncidentId] = useState<string | null>(null);
   const [dismissedIncidentIds, setDismissedIncidentIds] = useState<string[]>([]);
@@ -1747,8 +1797,30 @@ export function LiveScreen({
   );
 
   useEffect(() => {
-    setActiveSeries(resolution === '1min' ? MINUTE_DEFAULT_SERIES : SERIES_ORDER);
+    setActiveSeries((current) => {
+      if (current.length === 0) {
+        return resolution === '1min' ? MINUTE_DEFAULT_SERIES : SERIES_ORDER;
+      }
+
+      const next = current.filter((series) => SERIES_ORDER.includes(series));
+      return next.length > 0 ? next : resolution === '1min' ? MINUTE_DEFAULT_SERIES : SERIES_ORDER;
+    });
   }, [resolution]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        chartPrefsStorageKey,
+        JSON.stringify({
+          resolution,
+          viewMode,
+          activeSeries,
+        }),
+      );
+    } catch {
+      // Ignore storage failures and keep the UI functional in-memory.
+    }
+  }, [activeSeries, chartPrefsStorageKey, resolution, viewMode]);
 
   useEffect(() => {
     try {

--- a/apps/web/app/live/LiveScreen.tsx
+++ b/apps/web/app/live/LiveScreen.tsx
@@ -184,8 +184,25 @@ function getUptimeTone(uptimePercent: number): { border: string; background: str
   return {
     border: mixColor(tone, [15, 23, 42], 0.25),
     background: mixColor(tone, [2, 6, 23], 0.12),
-    text: mixColor(tone, [255, 255, 255], 0.1),
+    text: 'rgb(255 255 255)',
   };
+}
+
+function formatUptimePercent(uptimePercent: number): string {
+  return `${Math.round(uptimePercent)}%`;
+}
+
+function formatMissingMinutesSummary(expectedMinutes: number, coveredMinutes: number): string {
+  const missingMinutes = Math.max(0, expectedMinutes - coveredMinutes);
+  if (missingMinutes === 0) {
+    return 'Provider coverage is complete for the selected period.';
+  }
+
+  return `Provider coverage is slightly below complete: ${missingMinutes} minute${
+    missingMinutes === 1 ? '' : 's'
+  } ${missingMinutes === 1 ? 'is' : 'are'} missing, but ${
+    missingMinutes === 1 ? 'it does' : 'they do'
+  } not cross the outage threshold.`;
 }
 
 function getDismissalStorageKey(date: string, timezone: string): string {
@@ -551,7 +568,7 @@ function WarningDetailsModal({
           </div>
           <div className="mt-2 flex items-center justify-between gap-3">
             <span className="text-slate-400">Uptime today</span>
-            <span className="font-mono">{Math.round(health.uptimePercent)}%</span>
+            <span className="font-mono">{formatUptimePercent(health.uptimePercent)}</span>
           </div>
         </div>
         {selectedIncident ? (
@@ -572,8 +589,7 @@ function WarningDetailsModal({
           </>
         ) : (
           <p className="mt-4 text-sm text-slate-400">
-            No suspicious outage periods are currently active for this day, but the provider
-            coverage for the selected period is still below 100%.
+            {formatMissingMinutesSummary(health.expectedMinutes, health.coveredMinutes)}
           </p>
         )}
         {health.incidents.length > 0 && (
@@ -658,7 +674,7 @@ function UptimeBadge({
         color: tone.text,
       }}
     >
-      {label} {Math.round(uptimePercent)}%
+      {label} {formatUptimePercent(uptimePercent)}
     </button>
   );
 }

--- a/apps/web/app/live/LiveScreen.tsx
+++ b/apps/web/app/live/LiveScreen.tsx
@@ -1072,6 +1072,7 @@ function LiveTrendChart({
   activeSeries: SeriesKey[];
   onToggleSeries: (series: SeriesKey) => void;
 }) {
+  const [hoveredSeries, setHoveredSeries] = useState<SeriesKey | null>(null);
   const isStale = screenState === 'stale' || screenState === 'warning';
   const cumulativeUsesEnergyUnits = viewMode === 'cumulative' && resolution !== '1min';
   const axisUnit = cumulativeUsesEnergyUnits ? 'kWh' : 'kW';
@@ -1121,28 +1122,33 @@ function LiveTrendChart({
         </div>
       )}
 
-      <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="mt-4 grid gap-1.5 sm:grid-cols-2 lg:grid-cols-5">
         {SERIES_ORDER.map((series) => {
           const active = activeSeries.includes(series);
+          const isHovered = hoveredSeries === series;
           return (
             <button
               key={series}
               onClick={() => onToggleSeries(series)}
-              className={`flex min-w-0 items-center justify-between gap-2 rounded-xl border px-2.5 py-2 text-left text-[11px] leading-none transition-colors ${
+              onMouseEnter={() => setHoveredSeries(series)}
+              onMouseLeave={() => setHoveredSeries(null)}
+              className={`flex min-w-0 items-center gap-1 rounded-xl border px-2 py-1.5 text-left text-[12px] leading-none transition-colors ${
                 active
-                  ? 'border-slate-600 bg-slate-900/70 text-slate-100'
+                  ? isHovered
+                    ? 'border-slate-500 bg-slate-900 text-slate-50'
+                    : 'border-slate-600 bg-slate-900/70 text-slate-100'
                   : 'border-slate-800 bg-slate-950/60 text-slate-500'
               }`}
             >
-              <span className="flex min-w-0 items-center gap-1.5 whitespace-nowrap">
+              <span className="flex min-w-0 items-center gap-1 whitespace-nowrap">
                 <span
-                  className="h-2 w-2 shrink-0 rounded-full"
+                  className="h-1.5 w-1.5 shrink-0 rounded-full"
                   style={{ backgroundColor: SERIES_COLORS[series] }}
                 />
                 <span className="truncate">{formatSeriesLabel(series)}</span>
               </span>
-              <span className="shrink-0 text-[10px] text-slate-400">
-                {active ? <Eye size={13} /> : <EyeOff size={13} />}
+              <span className="ml-auto shrink-0 text-[11px] text-slate-400">
+                {active ? <Eye size={12} /> : <EyeOff size={12} />}
               </span>
             </button>
           );
@@ -1206,8 +1212,17 @@ function LiveTrendChart({
                   dataKey={series}
                   stroke={SERIES_COLORS[series]}
                   fill={`url(#fill-${series})`}
-                  fillOpacity={showFilledMinuteView ? 0.5 : 0}
-                  strokeWidth={series === 'import' ? 1 : 1.25}
+                  fillOpacity={
+                    showFilledMinuteView
+                      ? hoveredSeries && hoveredSeries !== series
+                        ? 0.08
+                        : 0.5
+                      : 0
+                  }
+                  strokeOpacity={hoveredSeries && hoveredSeries !== series ? 0.2 : 1}
+                  strokeWidth={
+                    hoveredSeries === series ? 2 : series === 'import' ? 1 : 1.25
+                  }
                   activeDot={{ r: 2.5, strokeWidth: 0 }}
                   dot={false}
                 />
@@ -1314,7 +1329,7 @@ function ValuePanel({
 
   const items = [
     {
-      label: 'Import cost so far',
+      label: 'Import cost',
       value: formatEuro(estimate.importCost),
       tone: 'text-rose-300',
     },
@@ -1340,9 +1355,7 @@ function ValuePanel({
       <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
         Today value
       </p>
-      <h3 className="mt-1 text-lg font-semibold text-slate-50">
-        Energy and money are telling the same story
-      </h3>
+      <h3 className="mt-1 text-lg font-semibold text-slate-50">Cost and savings so far</h3>
       <div className="mt-4 space-y-3">
         {items.map((item) => (
           <div key={item.label} className="flex items-baseline justify-between gap-3">

--- a/apps/web/app/live/LiveScreen.tsx
+++ b/apps/web/app/live/LiveScreen.tsx
@@ -65,7 +65,19 @@ export type LiveScreenProps = {
     minutesStale: number | null;
     lastReadingLocalTime: string | null;
     refreshedAtLocalTime: string;
-    warningDetails: {
+    uptimePercent: number;
+    expectedMinutes: number;
+    coveredMinutes: number;
+    incidents: {
+      id: string;
+      kind: 'missing-interval';
+      missingMinutes: number;
+      gapStartsAt: string;
+      gapEndsAt: string;
+      message: string;
+    }[];
+    primaryIncident: {
+      id: string;
       kind: 'missing-interval';
       missingMinutes: number;
       gapStartsAt: string;
@@ -137,6 +149,47 @@ function applyViewMode(data: LivePoint[], viewMode: ViewMode, resolution: Resolu
       intervalHours: point.intervalHours,
     };
   });
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function mixColor(a: [number, number, number], b: [number, number, number], t: number): string {
+  const ratio = clamp(t, 0, 1);
+  const rgb = a.map((channel, index) => Math.round(channel + (b[index] - channel) * ratio));
+  return `rgb(${rgb[0]} ${rgb[1]} ${rgb[2]})`;
+}
+
+function getUptimeTone(uptimePercent: number): { border: string; background: string; text: string } {
+  const red: [number, number, number] = [239, 68, 68];
+  const orange: [number, number, number] = [249, 115, 22];
+  const green: [number, number, number] = [34, 197, 94];
+
+  let tone = red;
+  if (uptimePercent >= 90) {
+    tone = uptimePercent >= 100 ? green : [
+      Math.round(249 + (34 - 249) * ((uptimePercent - 90) / 10)),
+      Math.round(115 + (197 - 115) * ((uptimePercent - 90) / 10)),
+      Math.round(22 + (94 - 22) * ((uptimePercent - 90) / 10)),
+    ];
+  } else if (uptimePercent >= 80) {
+    tone = [
+      Math.round(239 + (249 - 239) * ((uptimePercent - 80) / 10)),
+      Math.round(68 + (115 - 68) * ((uptimePercent - 80) / 10)),
+      Math.round(68 + (22 - 68) * ((uptimePercent - 80) / 10)),
+    ];
+  }
+
+  return {
+    border: mixColor(tone, [15, 23, 42], 0.25),
+    background: mixColor(tone, [2, 6, 23], 0.12),
+    text: mixColor(tone, [255, 255, 255], 0.1),
+  };
+}
+
+function getDismissalStorageKey(date: string, timezone: string): string {
+  return `pv-manager:live-warning-dismissals:${timezone}:${date}`;
 }
 
 function applyCostViewMode(data: CostPoint[], viewMode: ViewMode): CostPoint[] {
@@ -339,12 +392,10 @@ function NavBar({ screenState }: { screenState: ScreenState }) {
 function TrustBadge({
   screenState,
   health,
-  dismissed,
   onOpenDetails,
 }: {
   screenState: ScreenState;
   health: LiveScreenProps['health'];
-  dismissed?: boolean;
   onOpenDetails?: () => void;
 }) {
   function label(): string {
@@ -356,7 +407,7 @@ function TrustBadge({
           ? `Last reading ${health.lastReadingLocalTime}`
           : 'Data delayed';
       case 'warning':
-        return dismissed ? 'Data quality note dismissed' : 'Data quality review needed';
+        return 'Data quality review needed';
       case 'disconnected':
         return 'Provider disconnected';
     }
@@ -397,15 +448,12 @@ function TrustBadge({
 function WarningBanner({
   screenState,
   health,
-  dismissed,
   onOpenDetails,
 }: {
   screenState: ScreenState;
   health: LiveScreenProps['health'];
-  dismissed?: boolean;
   onOpenDetails?: () => void;
 }) {
-  if (screenState === 'warning' && dismissed) return null;
   if (screenState === 'healthy') return null;
 
   const config = {
@@ -419,7 +467,7 @@ function WarningBanner({
     warning: {
       title: 'A data gap needs review',
       body:
-        health.warningDetails?.message ??
+        health.primaryIncident?.message ??
         'A recent interval contains an unusual gap or missing live readings.',
       cta: 'Review details',
       className: 'border-orange-500/20 bg-orange-500/10 text-orange-200',
@@ -457,39 +505,109 @@ function WarningBanner({
 function WarningDetailsModal({
   health,
   open,
+  selectedIncidentId,
+  dismissedIncidentIds,
   onClose,
   onDismiss,
 }: {
   health: LiveScreenProps['health'];
   open: boolean;
+  selectedIncidentId: string | null;
+  dismissedIncidentIds: string[];
   onClose: () => void;
-  onDismiss: () => void;
+  onDismiss: (incidentId: string) => void;
 }) {
-  if (!open || !health.warningDetails) return null;
+  if (!open) return null;
+
+  const selectedIncident =
+    health.incidents.find((incident) => incident.id === selectedIncidentId) ??
+    health.primaryIncident ??
+    health.incidents[0] ??
+    null;
+  const selectedIncidentDismissed =
+    selectedIncident !== null && dismissedIncidentIds.includes(selectedIncident.id);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/75 px-4">
-      <div className="w-full max-w-md rounded-[28px] border border-slate-800 bg-[#111b2b] p-5 shadow-[0_30px_80px_rgba(2,6,23,0.55)]">
+      <div className="w-full max-w-lg rounded-[28px] border border-slate-800 bg-[#111b2b] p-5 shadow-[0_30px_80px_rgba(2,6,23,0.55)]">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
           Data quality
         </p>
-        <h3 className="mt-1 text-lg font-semibold text-slate-50">Missing live readings detected</h3>
-        <p className="mt-3 text-sm text-slate-300">{health.warningDetails.message}</p>
+        <h3 className="mt-1 text-lg font-semibold text-slate-50">
+          {health.incidents.length > 0
+            ? `${health.incidents.length} outage${health.incidents.length === 1 ? '' : 's'} detected today`
+            : 'Data quality overview'}
+        </h3>
+        <p className="mt-3 text-sm text-slate-300">
+          Based on expected provider minute coverage
+          {health.expectedMinutes > 0 ? ` so far today.` : '.'}
+        </p>
         <div className="mt-4 rounded-2xl border border-slate-800 bg-slate-950/70 px-3 py-3 text-sm text-slate-300">
           <div className="flex items-center justify-between gap-3">
-            <span className="text-slate-400">Gap window</span>
+            <span className="text-slate-400">Coverage</span>
             <span className="font-mono">
-              {health.warningDetails.gapStartsAt} to {health.warningDetails.gapEndsAt}
+              {health.coveredMinutes} / {health.expectedMinutes} mins
             </span>
           </div>
           <div className="mt-2 flex items-center justify-between gap-3">
-            <span className="text-slate-400">Missing minutes</span>
-            <span className="font-mono">{health.warningDetails.missingMinutes}</span>
+            <span className="text-slate-400">Uptime today</span>
+            <span className="font-mono">{Math.round(health.uptimePercent)}%</span>
           </div>
         </div>
+        {selectedIncident ? (
+          <>
+            <p className="mt-4 text-sm text-slate-300">{selectedIncident.message}</p>
+            <div className="mt-4 rounded-2xl border border-slate-800 bg-slate-950/70 px-3 py-3 text-sm text-slate-300">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-slate-400">Active selection</span>
+                <span className="font-mono">
+                  {selectedIncident.gapStartsAt} to {selectedIncident.gapEndsAt}
+                </span>
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-3">
+                <span className="text-slate-400">Missing minutes</span>
+                <span className="font-mono">{selectedIncident.missingMinutes}</span>
+              </div>
+            </div>
+          </>
+        ) : (
+          <p className="mt-4 text-sm text-slate-400">
+            No suspicious outage periods are currently active for this day, but the provider
+            coverage for the selected period is still below 100%.
+          </p>
+        )}
+        {health.incidents.length > 0 && (
+          <div className="mt-4 space-y-2 rounded-2xl border border-slate-800 bg-slate-950/50 px-3 py-3">
+            {health.incidents.map((incident) => (
+              <div
+                key={incident.id}
+                className={`rounded-2xl border px-3 py-3 text-sm ${
+                  incident.id === selectedIncident?.id
+                    ? 'border-orange-500/30 bg-orange-500/10'
+                    : 'border-slate-800 bg-slate-950/60'
+                }`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="font-medium text-slate-200">
+                    {incident.gapStartsAt} to {incident.gapEndsAt}
+                  </span>
+                  <span className="flex items-center gap-2 font-mono text-slate-400">
+                    <span>{incident.missingMinutes} mins</span>
+                    {dismissedIncidentIds.includes(incident.id) && (
+                      <span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-slate-500">
+                        Dismissed
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-slate-400">{incident.message}</p>
+              </div>
+            ))}
+          </div>
+        )}
         <p className="mt-4 text-sm text-slate-400">
-          This note is based on missing minute records in the provider feed. If you trust the data,
-          you can dismiss the warning for this session.
+          This note is based on missing minute records in the provider feed. Dismissal is stored in
+          this browser for the selected day, and dismissed incidents remain visible here for review.
         </p>
         <div className="mt-5 flex flex-wrap justify-end gap-2">
           <button
@@ -499,16 +617,49 @@ function WarningDetailsModal({
           >
             Close
           </button>
-          <button
-            type="button"
-            onClick={onDismiss}
-            className="rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950"
-          >
-            Dismiss warning
-          </button>
+          {selectedIncident && !selectedIncidentDismissed && (
+            <button
+              type="button"
+              onClick={() => onDismiss(selectedIncident.id)}
+              className="rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950"
+            >
+              Dismiss warning
+            </button>
+          )}
         </div>
       </div>
     </div>
+  );
+}
+
+function UptimeBadge({
+  uptimePercent,
+  isDisconnected,
+  isHistoricalDate,
+  onOpenDetails,
+}: {
+  uptimePercent: number;
+  isDisconnected: boolean;
+  isHistoricalDate: boolean;
+  onOpenDetails: () => void;
+}) {
+  const tone = getUptimeTone(uptimePercent);
+  const label = isDisconnected ? 'No feed' : isHistoricalDate ? 'Day uptime' : 'Uptime today';
+
+  return (
+    <button
+      type="button"
+      onClick={onOpenDetails}
+      title={label}
+      className="rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors"
+      style={{
+        borderColor: tone.border,
+        backgroundColor: tone.background,
+        color: tone.text,
+      }}
+    >
+      {label} {Math.round(uptimePercent)}%
+    </button>
   );
 }
 
@@ -1525,7 +1676,8 @@ export function LiveScreen({
   const [viewMode, setViewMode] = useState<ViewMode>('line');
   const [activeSeries, setActiveSeries] = useState<SeriesKey[]>(MINUTE_DEFAULT_SERIES);
   const [warningDetailsOpen, setWarningDetailsOpen] = useState(false);
-  const [warningDismissed, setWarningDismissed] = useState(false);
+  const [selectedIncidentId, setSelectedIncidentId] = useState<string | null>(null);
+  const [dismissedIncidentIds, setDismissedIncidentIds] = useState<string[]>([]);
   const [liveTime, setLiveTime] = useState(initialLiveTime);
 
   const baseChartData = useMemo(() => {
@@ -1552,16 +1704,65 @@ export function LiveScreen({
         )
       : null;
 
+  const dismissalStorageKey = useMemo(
+    () => getDismissalStorageKey(selectedDate, timezone),
+    [selectedDate, timezone],
+  );
+  const activeIncidents = useMemo(
+    () => health.incidents.filter((incident) => !dismissedIncidentIds.includes(incident.id)),
+    [dismissedIncidentIds, health.incidents],
+  );
+  const primaryActiveIncident = activeIncidents[0] ?? null;
+
   const displayScreenState: ScreenState =
-    screenState === 'warning' && warningDismissed
+    screenState === 'warning' && !primaryActiveIncident
       ? (health.minutesStale ?? 0) > 30
         ? 'stale'
         : 'healthy'
       : screenState;
 
+  const displayHealth = useMemo(
+    () => ({
+      ...health,
+      incidents: health.incidents,
+      primaryIncident: primaryActiveIncident,
+    }),
+    [health, primaryActiveIncident],
+  );
+
   useEffect(() => {
     setActiveSeries(resolution === '1min' ? MINUTE_DEFAULT_SERIES : SERIES_ORDER);
   }, [resolution]);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(dismissalStorageKey);
+      if (!raw) {
+        setDismissedIncidentIds([]);
+        return;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        setDismissedIncidentIds(parsed.filter((id): id is string => typeof id === 'string'));
+      } else {
+        setDismissedIncidentIds([]);
+      }
+    } catch {
+      setDismissedIncidentIds([]);
+    }
+  }, [dismissalStorageKey]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        dismissalStorageKey,
+        JSON.stringify(dismissedIncidentIds.filter((id) => health.incidents.some((incident) => incident.id === id))),
+      );
+    } catch {
+      // Ignore storage failures and fall back to in-memory state.
+    }
+  }, [dismissalStorageKey, dismissedIncidentIds, health.incidents]);
 
   useEffect(() => {
     if (isHistoricalDate) return;
@@ -1637,18 +1838,22 @@ export function LiveScreen({
       <NavBar screenState={displayScreenState} />
       <WarningBanner
         screenState={displayScreenState}
-        health={health}
-        dismissed={warningDismissed}
-        onOpenDetails={() => setWarningDetailsOpen(true)}
+        health={displayHealth}
+        onOpenDetails={() => {
+          setSelectedIncidentId(primaryActiveIncident?.id ?? health.primaryIncident?.id ?? null);
+          setWarningDetailsOpen(true);
+        }}
       />
 
       <div className="border-b border-slate-800 bg-[#0c1422]/80">
         <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6">
           <TrustBadge
             screenState={displayScreenState}
-            health={health}
-            dismissed={warningDismissed}
-            onOpenDetails={() => setWarningDetailsOpen(true)}
+            health={displayHealth}
+            onOpenDetails={() => {
+              setSelectedIncidentId(primaryActiveIncident?.id ?? health.primaryIncident?.id ?? null);
+              setWarningDetailsOpen(true);
+            }}
           />
           <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
             <DatePickerControl
@@ -1661,9 +1866,15 @@ export function LiveScreen({
             <span className="inline-flex min-w-[92px] justify-center rounded-full border border-slate-700 bg-slate-900/70 px-3 py-1.5">
               {liveTime}
             </span>
-            <span className="rounded-full border border-slate-700 bg-slate-900/70 px-3 py-1.5">
-              {isDisconnected ? 'No feed' : isHistoricalDate ? 'Selected day' : 'Live now'}
-            </span>
+            <UptimeBadge
+              uptimePercent={health.uptimePercent}
+              isDisconnected={isDisconnected}
+              isHistoricalDate={isHistoricalDate}
+              onOpenDetails={() => {
+                setSelectedIncidentId(primaryActiveIncident?.id ?? health.primaryIncident?.id ?? null);
+                setWarningDetailsOpen(true);
+              }}
+            />
           </div>
         </div>
       </div>
@@ -1784,12 +1995,20 @@ export function LiveScreen({
         )}
       </main>
       <WarningDetailsModal
-        health={health}
+        health={displayHealth}
         open={warningDetailsOpen}
+        selectedIncidentId={selectedIncidentId}
+        dismissedIncidentIds={dismissedIncidentIds}
         onClose={() => setWarningDetailsOpen(false)}
-        onDismiss={() => {
-          setWarningDismissed(true);
-          setWarningDetailsOpen(false);
+        onDismiss={(incidentId) => {
+          setDismissedIncidentIds((current) =>
+            current.includes(incidentId) ? current : [...current, incidentId],
+          );
+          const nextIncident = activeIncidents.find((incident) => incident.id !== incidentId);
+          setSelectedIncidentId(nextIncident?.id ?? incidentId);
+          if (!nextIncident && activeIncidents.length <= 1) {
+            setWarningDetailsOpen(false);
+          }
         }}
       />
     </div>

--- a/apps/web/app/live/page.tsx
+++ b/apps/web/app/live/page.tsx
@@ -141,7 +141,11 @@ export default async function LivePage({
           second: '2-digit',
           hour12: false,
         }).format(now),
-        warningDetails: dayDetail.health.warningDetails,
+        uptimePercent: dayDetail.health.uptimePercent,
+        expectedMinutes: dayDetail.health.expectedMinutes,
+        coveredMinutes: dayDetail.health.coveredMinutes,
+        incidents: dayDetail.health.incidents,
+        primaryIncident: dayDetail.health.primaryIncident,
       }}
       timezone={effectiveTimezone}
       hasTariff={tariffContext !== null}

--- a/apps/web/src/live/__tests__/normalizer.test.ts
+++ b/apps/web/src/live/__tests__/normalizer.test.ts
@@ -196,6 +196,26 @@ describe('buildHealth', () => {
     expect(health.primaryIncident).toBeNull();
   });
 
+  it('counts the repeated fall-back hour in expected and covered minutes', () => {
+    const minutes: MinuteReading[] = [];
+
+    for (let h = 0; h < 24; h++) {
+      for (let m = 0; m < 60; m++) {
+        minutes.push(makeMinute(h, m));
+        if (h === 1) {
+          minutes.push(makeMinute(h, m));
+        }
+      }
+    }
+
+    const health = buildHealth('2026-10-25', minutes, '2026-10-26T10:00:00.000Z', 'Europe/Dublin');
+
+    expect(health.recordCount).toBe(1500);
+    expect(health.expectedMinutes).toBe(1500);
+    expect(health.coveredMinutes).toBe(1500);
+    expect(health.uptimePercent).toBe(100);
+  });
+
   it('does not flag a gap that only exists in future-labelled minutes for the current local day', () => {
     const minutes: MinuteReading[] = [];
 
@@ -239,9 +259,9 @@ describe('buildHealth', () => {
 
     const health = buildHealth('2026-03-30', minutes, '2026-03-30T00:09:52.000Z', 'Europe/Dublin');
 
-    expect(health.expectedMinutes).toBe(70);
+    expect(health.expectedMinutes).toBe(69);
     expect(health.coveredMinutes).toBe(5);
-    expect(health.uptimePercent).toBeCloseTo(7.142857142857142);
+    expect(health.uptimePercent).toBeCloseTo(7.246376811594203);
   });
 });
 

--- a/apps/web/src/live/__tests__/normalizer.test.ts
+++ b/apps/web/src/live/__tests__/normalizer.test.ts
@@ -126,7 +126,12 @@ describe('buildHealth', () => {
     expect(health.recordCount).toBe(1440);
     expect(health.isPartialDay).toBe(false);
     expect(health.completenessRatio).toBe(1);
+    expect(health.expectedMinutes).toBe(1440);
+    expect(health.coveredMinutes).toBe(1440);
+    expect(health.uptimePercent).toBe(100);
     expect(health.hasSuspiciousReadings).toBe(false);
+    expect(health.incidents).toEqual([]);
+    expect(health.primaryIncident).toBeNull();
   });
 
   it('marks partial day when fewer than 1440 records', () => {
@@ -161,13 +166,15 @@ describe('buildHealth', () => {
     }
     const health = buildHealth(normalDate, minutes, fetchedAt);
     expect(health.hasSuspiciousReadings).toBe(true);
-    expect(health.warningDetails).toEqual({
+    expect(health.incidents).toEqual([{
+      id: 'missing-interval:10-16:7',
       kind: 'missing-interval',
       missingMinutes: 7,
       gapStartsAt: '00:10',
       gapEndsAt: '00:16',
       message: 'Missing 7 consecutive minute readings between 00:10 and 00:16.',
-    });
+    }]);
+    expect(health.primaryIncident).toEqual(health.incidents[0]);
   });
 
   it('does not flag the spring-forward hour as missing in Europe/Dublin', () => {
@@ -183,8 +190,10 @@ describe('buildHealth', () => {
     expect(health.recordCount).toBe(1380);
     expect(health.isPartialDay).toBe(false);
     expect(health.completenessRatio).toBe(1);
+    expect(health.uptimePercent).toBe(100);
     expect(health.hasSuspiciousReadings).toBe(false);
-    expect(health.warningDetails).toBeNull();
+    expect(health.incidents).toEqual([]);
+    expect(health.primaryIncident).toBeNull();
   });
 
   it('does not flag a gap that only exists in future-labelled minutes for the current local day', () => {
@@ -201,7 +210,38 @@ describe('buildHealth', () => {
     const health = buildHealth('2026-03-30', minutes, '2026-03-30T00:04:52.000Z', 'Europe/Dublin');
 
     expect(health.hasSuspiciousReadings).toBe(false);
-    expect(health.warningDetails).toBeNull();
+    expect(health.incidents).toEqual([]);
+    expect(health.primaryIncident).toBeNull();
+  });
+
+  it('collects multiple suspicious incidents in chronological order', () => {
+    const minutes: MinuteReading[] = [];
+
+    for (let m = 0; m < 60; m++) {
+      if ((m >= 10 && m <= 16) || (m >= 30 && m <= 39)) continue;
+      minutes.push(makeMinute(0, m));
+    }
+
+    const health = buildHealth(normalDate, minutes, fetchedAt);
+
+    expect(health.incidents.map((incident) => incident.id)).toEqual([
+      'missing-interval:10-16:7',
+      'missing-interval:30-39:10',
+    ]);
+    expect(health.primaryIncident?.id).toBe('missing-interval:10-16:7');
+  });
+
+  it('computes current-day uptime from expected minutes so far', () => {
+    const minutes: MinuteReading[] = [];
+    for (let m = 0; m <= 4; m++) {
+      minutes.push(makeMinute(0, m));
+    }
+
+    const health = buildHealth('2026-03-30', minutes, '2026-03-30T00:09:52.000Z', 'Europe/Dublin');
+
+    expect(health.expectedMinutes).toBe(70);
+    expect(health.coveredMinutes).toBe(5);
+    expect(health.uptimePercent).toBeCloseTo(7.142857142857142);
   });
 });
 

--- a/apps/web/src/live/normalizer.ts
+++ b/apps/web/src/live/normalizer.ts
@@ -1,4 +1,4 @@
-import type { MinuteReading, PeriodReading, DayDetailResponse } from './types';
+import type { MinuteReading, PeriodReading, DayDetailResponse, HealthIncident } from './types';
 
 // Gap threshold: flag suspicious if more than 5 consecutive minutes are missing
 const SUSPICIOUS_GAP_THRESHOLD = 5;
@@ -221,6 +221,10 @@ export function buildHealth(
 ): DayDetailResponse['health'] {
   const { expectedRecordCount, validOffsets } = getLocalTimeline(date, timezone);
   const gapScanUpperBound = getGapScanUpperBound(date, timezone, fetchedAt, validOffsets);
+  const expectedMinutes =
+    gapScanUpperBound === null
+      ? 0
+      : Array.from(validOffsets).filter((offset) => offset <= gapScanUpperBound).length;
   const recordCount = minutes.length;
   const completenessRatio = expectedRecordCount > 0 ? recordCount / expectedRecordCount : 0;
   const isPartialDay = recordCount < expectedRecordCount;
@@ -236,17 +240,15 @@ export function buildHealth(
           (gapScanUpperBound === null || offset <= gapScanUpperBound),
       ),
   );
+  const coveredMinutes = presentMinutes.size;
+  const uptimePercent = expectedMinutes > 0 ? (coveredMinutes / expectedMinutes) * 100 : 0;
 
   // Find the range actually covered: from first to last record
   const allOffsets = Array.from(presentMinutes).sort((a, b) => a - b);
   let hasSuspiciousReadings = false;
-  let warningDetails: DayDetailResponse['health']['warningDetails'] = null;
+  const incidents: HealthIncident[] = [];
 
   if (allOffsets.length > 0) {
-    let maxGap = 0;
-    let gapStart: number | null = null;
-    let gapEnd: number | null = null;
-
     for (let i = 1; i < allOffsets.length; i++) {
       let gap = 0;
       let firstMissing: number | null = null;
@@ -259,31 +261,36 @@ export function buildHealth(
         lastMissing = offset;
       }
 
-      if (gap > maxGap && firstMissing !== null && lastMissing !== null) {
-        maxGap = gap;
-        gapStart = firstMissing;
-        gapEnd = lastMissing;
+      if (
+        gap > SUSPICIOUS_GAP_THRESHOLD &&
+        firstMissing !== null &&
+        lastMissing !== null
+      ) {
+        incidents.push({
+          id: `missing-interval:${firstMissing}-${lastMissing}:${gap}`,
+          kind: 'missing-interval',
+          missingMinutes: gap,
+          gapStartsAt: toClock(firstMissing),
+          gapEndsAt: toClock(lastMissing),
+          message: `Missing ${gap} consecutive minute readings between ${toClock(firstMissing)} and ${toClock(lastMissing)}.`,
+        });
       }
     }
-
-    hasSuspiciousReadings = maxGap > SUSPICIOUS_GAP_THRESHOLD;
-    if (hasSuspiciousReadings && gapStart !== null && gapEnd !== null) {
-      warningDetails = {
-        kind: 'missing-interval',
-        missingMinutes: maxGap,
-        gapStartsAt: toClock(gapStart),
-        gapEndsAt: toClock(gapEnd),
-        message: `Missing ${maxGap} consecutive minute readings between ${toClock(gapStart)} and ${toClock(gapEnd)}.`,
-      };
-    }
   }
+
+  incidents.sort((a, b) => a.gapStartsAt.localeCompare(b.gapStartsAt));
+  hasSuspiciousReadings = incidents.length > 0;
 
   return {
     recordCount,
     isPartialDay,
     completenessRatio,
+    expectedMinutes,
+    coveredMinutes,
+    uptimePercent,
     hasSuspiciousReadings,
-    warningDetails,
+    incidents,
+    primaryIncident: incidents[0] ?? null,
     fetchedAt,
   };
 }

--- a/apps/web/src/live/normalizer.ts
+++ b/apps/web/src/live/normalizer.ts
@@ -16,6 +16,7 @@ function toClock(minutesSinceMidnight: number): string {
 function getLocalTimeline(date: string, timezone: string): {
   expectedRecordCount: number;
   validOffsets: Set<number>;
+  timelineMinutes: Array<{ ts: number; offset: number }>;
 } {
   const [year, month, day] = date.split('-').map(Number);
   const formatter = new Intl.DateTimeFormat('en-CA', {
@@ -32,6 +33,7 @@ function getLocalTimeline(date: string, timezone: string): {
   const utcEnd = Date.UTC(year, month - 1, day + 1) + (18 * 60 * 60 * 1000);
   let expectedRecordCount = 0;
   const validOffsets = new Set<number>();
+  const timelineMinutes: Array<{ ts: number; offset: number }> = [];
 
   for (let ts = utcStart; ts < utcEnd; ts += 60 * 1000) {
     const parts = formatter.formatToParts(new Date(ts));
@@ -43,11 +45,13 @@ function getLocalTimeline(date: string, timezone: string): {
 
     const localHour = Number(parts.find((part) => part.type === 'hour')?.value ?? '0');
     const localMinute = Number(parts.find((part) => part.type === 'minute')?.value ?? '0');
+    const offset = localHour * 60 + localMinute;
     expectedRecordCount += 1;
-    validOffsets.add(localHour * 60 + localMinute);
+    validOffsets.add(offset);
+    timelineMinutes.push({ ts, offset });
   }
 
-  return { expectedRecordCount, validOffsets };
+  return { expectedRecordCount, validOffsets, timelineMinutes };
 }
 
 function getLocalDateParts(date: Date, timezone: string): {
@@ -75,15 +79,14 @@ function getLocalDateParts(date: Date, timezone: string): {
   return { year, month, day, offset: hour * 60 + minute };
 }
 
-function getGapScanUpperBound(
+function getCoverageUpperBoundTs(
   date: string,
   timezone: string,
   fetchedAt: string,
-  validOffsets: Set<number>,
+  timelineMinutes: Array<{ ts: number; offset: number }>,
 ): number | null {
-  if (validOffsets.size === 0) return null;
+  if (timelineMinutes.length === 0) return null;
 
-  const maxValidOffset = Math.max(...validOffsets);
   const fetchedAtLocal = getLocalDateParts(new Date(fetchedAt), timezone);
   const [year, month, day] = date.split('-').map(Number);
 
@@ -92,13 +95,18 @@ function getGapScanUpperBound(
     fetchedAtLocal.month === month &&
     fetchedAtLocal.day === day
   ) {
-    return Math.min(maxValidOffset, fetchedAtLocal.offset);
+    const fetchedMinuteStartTs = Math.floor(new Date(fetchedAt).getTime() / 60_000) * 60_000;
+    return fetchedMinuteStartTs;
   }
 
   const selectedDateUtc = Date.UTC(year, month - 1, day);
   const fetchedDateUtc = Date.UTC(fetchedAtLocal.year, fetchedAtLocal.month - 1, fetchedAtLocal.day);
 
-  return selectedDateUtc < fetchedDateUtc ? maxValidOffset : null;
+  if (selectedDateUtc < fetchedDateUtc) {
+    return timelineMinutes[timelineMinutes.length - 1]?.ts + 60_000;
+  }
+
+  return null;
 }
 
 function selfConsumptionRatio(consumedKwh: number, importKwh: number): number {
@@ -219,32 +227,41 @@ export function buildHealth(
   fetchedAt: string,
   timezone = 'Europe/Dublin',
 ): DayDetailResponse['health'] {
-  const { expectedRecordCount, validOffsets } = getLocalTimeline(date, timezone);
-  const gapScanUpperBound = getGapScanUpperBound(date, timezone, fetchedAt, validOffsets);
+  const { expectedRecordCount, validOffsets, timelineMinutes } = getLocalTimeline(date, timezone);
+  const coverageUpperBoundTs = getCoverageUpperBoundTs(date, timezone, fetchedAt, timelineMinutes);
   const expectedMinutes =
-    gapScanUpperBound === null
+    coverageUpperBoundTs === null
       ? 0
-      : Array.from(validOffsets).filter((offset) => offset <= gapScanUpperBound).length;
+      : timelineMinutes.filter((minute) => minute.ts < coverageUpperBoundTs).length;
   const recordCount = minutes.length;
   const completenessRatio = expectedRecordCount > 0 ? recordCount / expectedRecordCount : 0;
   const isPartialDay = recordCount < expectedRecordCount;
 
   // Ignore offsets that do not exist on the selected local day and any provider
   // records that appear to land after the local fetch time.
-  const presentMinutes = new Set(
+  const presentOffsets = new Set(
     minutes
       .map((m) => m.hour * 60 + m.minute)
       .filter(
         (offset) =>
           validOffsets.has(offset) &&
-          (gapScanUpperBound === null || offset <= gapScanUpperBound),
+          (coverageUpperBoundTs === null ||
+            timelineMinutes.some((minute) => minute.offset === offset && minute.ts < coverageUpperBoundTs)),
       ),
   );
-  const coveredMinutes = presentMinutes.size;
+  const coveredMinutes =
+    coverageUpperBoundTs === null
+      ? 0
+      : minutes.filter((m) =>
+          timelineMinutes.some(
+            (minute) =>
+              minute.offset === m.hour * 60 + m.minute && minute.ts < coverageUpperBoundTs,
+          ),
+        ).length;
   const uptimePercent = expectedMinutes > 0 ? (coveredMinutes / expectedMinutes) * 100 : 0;
 
   // Find the range actually covered: from first to last record
-  const allOffsets = Array.from(presentMinutes).sort((a, b) => a - b);
+  const allOffsets = Array.from(presentOffsets).sort((a, b) => a - b);
   let hasSuspiciousReadings = false;
   const incidents: HealthIncident[] = [];
 

--- a/apps/web/src/live/types.ts
+++ b/apps/web/src/live/types.ts
@@ -22,6 +22,15 @@ export type PeriodReading = {
   selfConsumptionRatio: number;
 };
 
+export type HealthIncident = {
+  id: string;
+  kind: 'missing-interval';
+  missingMinutes: number;
+  gapStartsAt: string;
+  gapEndsAt: string;
+  message: string;
+};
+
 export type DayDetailResponse = {
   meta: {
     date: string;
@@ -46,14 +55,12 @@ export type DayDetailResponse = {
     recordCount: number;
     isPartialDay: boolean;
     completenessRatio: number;
+    expectedMinutes: number;
+    coveredMinutes: number;
+    uptimePercent: number;
     hasSuspiciousReadings: boolean;
-    warningDetails: {
-      kind: 'missing-interval';
-      missingMinutes: number;
-      gapStartsAt: string;
-      gapEndsAt: string;
-      message: string;
-    } | null;
+    incidents: HealthIncident[];
+    primaryIncident: HealthIncident | null;
     fetchedAt: string;
   };
 };

--- a/apps/web/src/providers/v1/__tests__/adapter.test.ts
+++ b/apps/web/src/providers/v1/__tests__/adapter.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { fetchMinuteData } from '../adapter';
 
 describe('fetchMinuteData', () => {
-  it('keeps provider-local clock fields and filters out rows from other dates', async () => {
+  it('keeps provider-local clock fields even when the leading hour is tagged with the previous dom', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => [
+        { yr: 2026, mon: 3, dom: 29, dow: 'Mon', hr: 0, min: 0, imp: 1800 },
         { yr: 2026, mon: 3, dom: 29, dow: 'Mon', hr: 0, min: 59, imp: 3600 },
         { yr: 2026, mon: 3, dom: 30, dow: 'Mon', hr: 1, min: 0, imp: 3600 },
         { yr: 2026, mon: 3, dom: 30, dow: 'Mon', hr: 1, min: 1, imp: 7200 },
@@ -21,8 +22,32 @@ describe('fetchMinuteData', () => {
       { cache: 'no-store' },
     );
     expect(result).toEqual([
+      expect.objectContaining({ hour: 0, minute: 0, importKwh: 0.0005 }),
+      expect.objectContaining({ hour: 0, minute: 59, importKwh: 0.001 }),
       expect.objectContaining({ hour: 1, minute: 0, importKwh: 0.001 }),
       expect.objectContaining({ hour: 1, minute: 1, importKwh: 0.002 }),
+    ]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('drops trailing records once the V1 proxy wraps into the next local day', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { yr: 2026, mon: 3, dom: 29, dow: 'Sun', hr: 23, min: 58, imp: 3600 },
+        { yr: 2026, mon: 3, dom: 29, dow: 'Sun', hr: 23, min: 59, imp: 3600 },
+        { yr: 2026, mon: 3, dom: 30, dow: 'Mon', hr: 0, min: 0, imp: 3600 },
+      ],
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchMinuteData('2026-03-29', 'Europe/Dublin');
+
+    expect(result).toEqual([
+      expect.objectContaining({ hour: 23, minute: 58 }),
+      expect.objectContaining({ hour: 23, minute: 59 }),
     ]);
 
     vi.unstubAllGlobals();

--- a/apps/web/src/providers/v1/adapter.ts
+++ b/apps/web/src/providers/v1/adapter.ts
@@ -25,9 +25,18 @@ function selfConsumptionRatio(consumedKwh: number, importKwh: number): number {
   return solar / consumedKwh;
 }
 
-function isRequestedDate(record: V1MinuteRecord, date: string): boolean {
-  const [year, month, day] = date.split('-').map(Number);
-  return record.yr === year && record.mon === month && record.dom === day;
+function normalizeRequestedDayRecords(raw: V1MinuteRecord[]): V1MinuteRecord[] {
+  const normalized: V1MinuteRecord[] = [];
+  let previousOffset = -1;
+
+  for (const record of raw) {
+    const offset = (record.hr ?? 0) * 60 + (record.min ?? 0);
+    if (previousOffset > offset) break;
+    normalized.push(record);
+    previousOffset = offset;
+  }
+
+  return normalized;
 }
 
 function mapRecord(record: V1MinuteRecord): MinuteReading {
@@ -67,9 +76,13 @@ export async function fetchMinuteData(
       console.error(`[v1-adapter] unexpected response shape for date ${date}`);
       return [];
     }
-    return raw
-      .filter((record) => isRequestedDate(record, date))
-      .map((record) => mapRecord(record));
+
+    // The V1 proxy adjusts hour/minute for timezone and DST, but around BST
+    // boundaries it can leave the calendar date fields on the previous local
+    // day for an initial 00:00-00:59 block. Treat the returned clock-ordered
+    // slice as authoritative for the requested day, and stop at the first wrap
+    // back to an earlier clock minute.
+    return normalizeRequestedDayRecords(raw).map((record) => mapRecord(record));
   } catch (err) {
     console.error(`[v1-adapter] fetch failed for date ${date}`, err);
     return [];

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -770,7 +770,7 @@ type ProviderImportResult = {
 
 ### MyEnergi-specific first-pass assumptions
 
-- MyEnergi minute payloads can be requested by date, but the adapter should trust the returned local date fields when selecting the final local-day slice.
+- The legacy V1 MyEnergi proxy has a known DST-boundary quirk: it adjusts `hr`/`min` for timezone but can leave `dom`/`mon`/`yr` on the previous local day for the leading 00:00-00:59 block. Any future direct v2 MyEnergi adapter must normalize full timestamps at the adapter layer and must not trust partially shifted local date fields from this legacy proxy behavior.
 - Canonical consumption may be derived as `import + generation - export - immersionDiverted` when not provided directly.
 - Import, export, generation, and immersion values should stay distinct even when some are later combined in summaries or billing comparisons.
 


### PR DESCRIPTION
## Summary
- add incident-based live data health with uptime coverage for the selected day
- persist per-incident dismissals in localStorage and keep dismissed incidents reviewable in the modal
- replace the Live now pill with a clickable uptime badge and expand normalizer coverage tests

## Verification
- npm test -- --run src/live/__tests__/normalizer.test.ts
- npm test -- --run src/live/__tests__/loader.test.ts
- npm run build