### PR TITLE
feat(U-027): build polished Tariffs overview screen

### DIFF
--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRight,
   CheckCircle2,
   History,
+  X,
 } from 'lucide-react';
 import { loadTariffOverview } from '@/src/tariffs/loader';
 import type {
@@ -108,12 +109,13 @@ function deriveSchemes(schedule: string[], allPeriods: PricePeriod[]): TariffSch
 // ---------------------------------------------------------------------------
 
 const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
-const TIME_AXIS   = ['00:00', '03:00', '06:00', '09:00', '12:00', '15:00', '18:00', '21:00'];
 const SLOT_COUNT = 48;
 const MOBILE_SLOT_WIDTH = 12;
 const SLOT_GAP = 2;
 const SLOT_HEIGHT_MOBILE = 18;
 const DAY_PILL_SIZE = 42;
+const DESKTOP_LABEL_WIDTH = 250;
+const TWO_HOUR_MARKERS = Array.from({ length: 13 }, (_, i) => i * 2); // 0..24
 
 function gridWidth(slotWidth: number): number {
   return SLOT_COUNT * slotWidth + (SLOT_COUNT - 1) * SLOT_GAP;
@@ -122,6 +124,31 @@ function gridWidth(slotWidth: number): number {
 function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
   const daySet = new Set(scheme.days);
   const mobileWidth = gridWidth(MOBILE_SLOT_WIDTH);
+  const railInnerWidth = mobileWidth - MOBILE_SLOT_WIDTH; // 24 sits on the far edge
+
+  const renderPeriodControls = (period: PricePeriod) => (
+    <>
+      <div className="relative">
+        <span
+          className="pointer-events-none absolute left-2.5 top-1/2 h-2.5 w-2.5 -translate-y-1/2 rounded-sm"
+          style={{ backgroundColor: period.colourHex ?? '#64748b' }}
+        />
+        <div className="flex h-9 min-w-[88px] items-center rounded-xl border border-slate-700 bg-slate-950/70 pl-6 pr-3 text-sm font-medium text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+          {period.periodLabel}
+        </div>
+      </div>
+      <div className="flex h-9 min-w-[82px] items-center justify-between rounded-xl border border-slate-700 bg-slate-950/70 px-3 text-sm font-medium text-slate-100 tabular-nums shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+        <span>{formatRate(period.ratePerKwh, period.isFreeImport)}</span>
+      </div>
+      <button
+        type="button"
+        aria-label={`Remove ${period.periodLabel}`}
+        className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-slate-700 bg-slate-950/70 text-slate-400 transition-colors hover:border-slate-500 hover:text-slate-200"
+      >
+        <X size={14} />
+      </button>
+    </>
+  );
 
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/50 px-4 py-4">
@@ -166,33 +193,15 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
           <div className="flex flex-col gap-3">
             {scheme.periods.map((period) => (
               <div key={period.id}>
-                {/* Mobile label — above the bar */}
-                <div className="flex items-center gap-2 mb-1.5 md:hidden">
-                  <span
-                    className="h-2.5 w-2.5 rounded-sm shrink-0"
-                    style={{ backgroundColor: period.colourHex ?? '#64748b' }}
-                  />
-                  <span className="text-xs font-medium text-slate-300">
-                    {period.periodLabel}
-                  </span>
-                  <span className="text-xs text-slate-500 tabular-nums">
-                    {formatRate(period.ratePerKwh, period.isFreeImport)}
-                  </span>
+                {/* Mobile controls */}
+                <div className="mb-2 flex items-center gap-2 md:hidden">
+                  {renderPeriodControls(period)}
                 </div>
 
                 <div className="flex items-center gap-3">
                   {/* Desktop-only left label */}
-                  <div className="hidden md:flex w-36 shrink-0 items-center gap-2">
-                    <span
-                      className="h-2.5 w-2.5 rounded-sm shrink-0"
-                      style={{ backgroundColor: period.colourHex ?? '#64748b' }}
-                    />
-                    <span className="text-xs font-medium text-slate-300 truncate">
-                      {period.periodLabel}
-                    </span>
-                    <span className="text-xs text-slate-500 tabular-nums shrink-0">
-                      {formatRate(period.ratePerKwh, period.isFreeImport)}
-                    </span>
+                  <div className="hidden md:flex shrink-0 items-center gap-2" style={{ width: DESKTOP_LABEL_WIDTH }}>
+                    {renderPeriodControls(period)}
                   </div>
 
                   {/* Activity bar with deterministic slot geometry and 2-hour markers */}
@@ -223,14 +232,18 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                         );
                       })}
                     </div>
-                    {Array.from({ length: 11 }).map((_, idx) => {
-                      const slotIndex = (idx + 1) * 4;
-                      const mobileLeft = slotIndex * MOBILE_SLOT_WIDTH + slotIndex * SLOT_GAP - SLOT_GAP / 2;
+                    {TWO_HOUR_MARKERS.map((hour) => {
+                      const slotIndex = hour * 2;
+                      const left = Math.max(0, Math.min(mobileWidth, slotIndex * (MOBILE_SLOT_WIDTH + SLOT_GAP)));
+                      const isStrong = hour % 6 === 0;
                       return (
                         <div
-                          key={idx}
-                          className="pointer-events-none absolute inset-y-0 w-px bg-white/14"
-                          style={{ left: mobileLeft }}
+                          key={hour}
+                          className={[
+                            'pointer-events-none absolute inset-y-[-3px] border-l-2 border-dashed',
+                            isStrong ? 'border-white/70' : 'border-white/35',
+                          ].join(' ')}
+                          style={{ left }}
                         />
                       );
                     })}
@@ -241,18 +254,30 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
           </div>
 
           {/* Time axis — offset by label column on desktop, flush on mobile */}
-          <div
-            className="mt-2 grid text-[10px] text-slate-500 tabular-nums md:pl-[9.5rem]"
-            style={{
-              gridTemplateColumns: `repeat(8, ${mobileWidth / 8}px)`,
-              width: mobileWidth,
-            }}
-          >
-            {TIME_AXIS.map((t) => (
-              <div key={t}>
-                {t}
-              </div>
-            ))}
+          <div className="mt-2 flex items-start gap-3">
+            <div className="hidden md:block shrink-0" style={{ width: DESKTOP_LABEL_WIDTH }} />
+            <div className="relative h-5" style={{ width: mobileWidth }}>
+              {TWO_HOUR_MARKERS.map((hour) => {
+                const left = Math.max(
+                  0,
+                  Math.min(mobileWidth, hour * 2 * (MOBILE_SLOT_WIDTH + SLOT_GAP)),
+                );
+                const isStrong = hour % 6 === 0 || hour === 24;
+                const positionClass =
+                  hour === 0 ? 'translate-x-0' : hour === 24 ? '-translate-x-full' : '-translate-x-1/2';
+                return (
+                  <div
+                    key={hour}
+                    className={`absolute top-0 text-[10px] tabular-nums ${positionClass}`}
+                    style={{ left }}
+                  >
+                    <span className={isStrong ? 'font-semibold text-slate-300' : 'text-slate-500'}>
+                      {hour}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
 
         </div>

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -234,16 +234,25 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                     </div>
                     {TWO_HOUR_MARKERS.map((hour) => {
                       const slotIndex = hour * 2;
-                      const left = Math.max(0, Math.min(mobileWidth, slotIndex * (MOBILE_SLOT_WIDTH + SLOT_GAP)));
+                      const left =
+                        hour === 0
+                          ? -SLOT_GAP / 2
+                          : hour === 24
+                            ? mobileWidth + SLOT_GAP / 2
+                            : slotIndex * (MOBILE_SLOT_WIDTH + SLOT_GAP) - SLOT_GAP / 2;
                       const isStrong = hour % 6 === 0;
                       return (
                         <div
                           key={hour}
-                          className={[
-                            'pointer-events-none absolute inset-y-[-3px] border-l-2 border-dashed',
-                            isStrong ? 'border-white/70' : 'border-white/35',
-                          ].join(' ')}
-                          style={{ left }}
+                          className="pointer-events-none absolute inset-y-[-3px] w-px -translate-x-1/2"
+                          style={{
+                            left,
+                            backgroundImage: `repeating-linear-gradient(
+                              to bottom,
+                              ${isStrong ? 'rgba(255,255,255,0.78)' : 'rgba(255,255,255,0.42)'} 0 6px,
+                              transparent 6px 10px
+                            )`,
+                          }}
                         />
                       );
                     })}

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -112,7 +112,7 @@ const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 const SLOT_COUNT = 48;
 const MOBILE_SLOT_WIDTH = 12;
 const SLOT_GAP = 2;
-const SLOT_HEIGHT_MOBILE = 18;
+const SLOT_HEIGHT_MOBILE = 24;
 const DAY_PILL_SIZE = 42;
 const DESKTOP_LABEL_WIDTH = 250;
 const TWO_HOUR_MARKERS = Array.from({ length: 13 }, (_, i) => i * 2); // 0..24
@@ -125,6 +125,10 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
   const daySet = new Set(scheme.days);
   const mobileWidth = gridWidth(MOBILE_SLOT_WIDTH);
   const railInnerWidth = mobileWidth - MOBILE_SLOT_WIDTH; // 24 sits on the far edge
+  const ACTIVE_SLOT_FILL = '#3f4f67';
+  const ACTIVE_SLOT_BORDER = 'rgba(235,248,255,0.35)';
+  const INACTIVE_SLOT_FILL = '#27324a';
+  const INACTIVE_SLOT_BORDER = 'rgba(255,255,255,0.06)';
 
   const renderPeriodControls = (period: PricePeriod) => (
     <>
@@ -219,13 +223,12 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                         return (
                           <div
                             key={slot}
-                            className="rounded-[2px] md:rounded-[3px]"
+                            className="rounded-[1px]"
                             style={{
                               height: SLOT_HEIGHT_MOBILE,
-                              backgroundColor: isActive
-                                ? (period.colourHex ?? '#64748b')
-                                : '#1e293b',
-                              opacity: isActive ? 0.88 : 1,
+                              backgroundColor: isActive ? ACTIVE_SLOT_FILL : INACTIVE_SLOT_FILL,
+                              border: `1px solid ${isActive ? ACTIVE_SLOT_BORDER : INACTIVE_SLOT_BORDER}`,
+                              boxSizing: 'border-box',
                             }}
                             title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
                           />
@@ -244,12 +247,12 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                       return (
                         <div
                           key={hour}
-                          className="pointer-events-none absolute inset-y-[-3px] w-px -translate-x-1/2"
+                          className="pointer-events-none absolute inset-y-[-8px] w-px -translate-x-1/2"
                           style={{
                             left,
                             backgroundImage: `repeating-linear-gradient(
                               to bottom,
-                              ${isStrong ? 'rgba(255,255,255,0.78)' : 'rgba(255,255,255,0.42)'} 0 6px,
+                              ${isStrong ? 'rgba(74,222,128,0.95)' : 'rgba(74,222,128,0.58)'} 0 6px,
                               transparent 6px 10px
                             )`,
                           }}
@@ -288,8 +291,19 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
               })}
             </div>
           </div>
-
         </div>
+      </div>
+
+      <div className="mt-4">
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 text-sm font-medium text-emerald-400 transition-colors hover:text-emerald-300"
+        >
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border-2 border-emerald-400">
+            <Plus size={16} />
+          </span>
+          <span>Add price period</span>
+        </button>
       </div>
     </div>
   );

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -1,29 +1,577 @@
 import Link from 'next/link';
-import { Receipt, ArrowRight } from 'lucide-react';
+import {
+  Receipt,
+  Plus,
+  CalendarClock,
+  AlertTriangle,
+  Info,
+  ArrowRight,
+  CheckCircle2,
+  History,
+} from 'lucide-react';
+import { loadTariffOverview } from '@/src/tariffs/loader';
+import type { TariffVersionDetail, TariffVersionSummary, ContractInfo, PricePeriod } from '@/src/tariffs/loader';
 
-export default function TariffsPage() {
+export const dynamic = 'force-dynamic';
+
+const SEED_INSTALLATION_ID = '00000000-0000-0000-0000-000000000002';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat('en-IE', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(iso + 'T00:00:00'));
+}
+
+function formatRate(rate: string | null): string {
+  if (!rate) return '—';
+  const c = (parseFloat(rate) * 100).toFixed(2);
+  return `${c}¢`;
+}
+
+function formatStandingCharge(amount: string, unit: string): string {
+  const val = parseFloat(amount).toFixed(2);
+  if (unit === 'per_day') return `€${val}/day`;
+  if (unit === 'per_month') return `€${val}/mo`;
+  return `€${val}`;
+}
+
+/** Days until a local date string (YYYY-MM-DD). Negative = already past. */
+function daysUntil(localDate: string): number {
+  const target = new Date(localDate + 'T00:00:00');
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return Math.ceil((target.getTime() - now.getTime()) / 86_400_000);
+}
+
+// Slot index → HH:MM label (every 3 hours for axis labels)
+function slotToTime(slot: number): string {
+  const h = Math.floor(slot / 2);
+  const m = slot % 2 === 0 ? '00' : '30';
+  return `${String(h).padStart(2, '0')}:${m}`;
+}
+
+// ---------------------------------------------------------------------------
+// Contract reminder banner
+// ---------------------------------------------------------------------------
+
+function ContractBanner({ contract }: { contract: ContractInfo }) {
+  const reviewDays = contract.expectedReviewDate ? daysUntil(contract.expectedReviewDate) : null;
+  const endDays = contract.contractEndDate ? daysUntil(contract.contractEndDate) : null;
+
+  const isExpired = endDays !== null && endDays < 0;
+  const endingSoon = !isExpired && endDays !== null && endDays <= 90;
+  const reviewSoon = !isExpired && reviewDays !== null && reviewDays >= 0 && reviewDays <= 60;
+
+  if (!isExpired && !endingSoon && !reviewSoon) return null;
+
+  const isUrgent = isExpired || (endDays !== null && endDays <= 30);
+
+  return (
+    <div
+      className={[
+        'flex items-start gap-3 rounded-2xl border px-4 py-3.5',
+        isUrgent
+          ? 'border-red-800/40 bg-red-950/30'
+          : 'border-amber-700/30 bg-amber-950/20',
+      ].join(' ')}
+    >
+      <AlertTriangle
+        size={15}
+        className={['mt-0.5 shrink-0', isUrgent ? 'text-red-400' : 'text-amber-400'].join(' ')}
+      />
+      <div className="flex-1 min-w-0">
+        {isExpired && (
+          <p className="text-sm font-medium text-red-300">Contract expired</p>
+        )}
+        {!isExpired && endingSoon && endDays !== null && (
+          <p className={['text-sm font-medium', isUrgent ? 'text-red-300' : 'text-amber-300'].join(' ')}>
+            Contract ends in {endDays} day{endDays !== 1 ? 's' : ''}
+          </p>
+        )}
+        {!isExpired && !endingSoon && reviewSoon && reviewDays !== null && (
+          <p className="text-sm font-medium text-amber-300">
+            Tariff review due in {reviewDays} day{reviewDays !== 1 ? 's' : ''}
+          </p>
+        )}
+        <p className="mt-0.5 text-xs text-slate-400">
+          {contract.contractEndDate
+            ? `Contract end date: ${formatDate(contract.contractEndDate)}.`
+            : ''}{' '}
+          {contract.notes && <span className="text-slate-500">{contract.notes}</span>}
+        </p>
+      </div>
+      <Link
+        href="#"
+        className="shrink-0 inline-flex items-center gap-1 rounded-full border border-slate-700 px-3 py-1 text-xs font-medium text-slate-300 hover:border-slate-500 hover:text-slate-100 transition-colors"
+      >
+        Review <ArrowRight size={10} />
+      </Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Price period legend
+// ---------------------------------------------------------------------------
+
+function PeriodLegend({ periods }: { periods: PricePeriod[] }) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {periods.map((p) => (
+        <div key={p.id} className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2.5 w-2.5 rounded-sm"
+            style={{ backgroundColor: p.colourHex ?? '#64748b' }}
+          />
+          <span className="text-xs text-slate-300">{p.periodLabel}</span>
+          <span className="text-xs text-slate-500">{formatRate(p.ratePerKwh)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Weekly schedule preview (schedule-based)
+// 7 rows (Mon–Sun) × 48 columns (half-hours), each cell coloured by period
+// ---------------------------------------------------------------------------
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+// Show tick marks every 6 slots (3 hours): 00, 06, 12, 18, 24, 30, 36, 42
+const AXIS_TICKS = [0, 6, 12, 18, 24, 30, 36, 42, 48];
+
+function WeeklyScheduleGrid({
+  schedule,
+  periods,
+}: {
+  schedule: string[];
+  periods: PricePeriod[];
+}) {
+  const colourMap = new Map(periods.map((p) => [p.id, p.colourHex ?? '#64748b']));
+
   return (
     <div>
-      <div className="flex items-center gap-2 mb-6">
-        <Receipt size={18} className="text-slate-400" />
-        <h1 className="text-lg font-semibold text-slate-100">Tariffs</h1>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-xs font-medium text-slate-400">Weekly schedule</span>
       </div>
 
-      <p className="text-sm text-slate-400 leading-relaxed max-w-prose">
+      {/* Grid */}
+      <div className="overflow-x-auto">
+        <div style={{ minWidth: 360 }}>
+          {/* Time axis */}
+          <div className="flex mb-1 pl-8">
+            {AXIS_TICKS.map((tick) => (
+              <div
+                key={tick}
+                className="text-[9px] text-slate-600 tabular-nums"
+                style={{ width: `${(100 / 48) * (tick === 48 ? 0 : 1)}%`, flexShrink: 0 }}
+              >
+                {tick < 48 ? slotToTime(tick) : ''}
+              </div>
+            ))}
+          </div>
+
+          {/* Day rows */}
+          {DAY_LABELS.map((day, dayIdx) => (
+            <div key={day} className="flex items-center gap-1 mb-0.5">
+              <span className="w-7 shrink-0 text-[10px] text-slate-500 text-right pr-1">{day}</span>
+              <div className="flex flex-1 gap-px">
+                {Array.from({ length: 48 }, (_, slot) => {
+                  const periodId = schedule[dayIdx * 48 + slot];
+                  const colour = colourMap.get(periodId) ?? '#1e293b';
+                  return (
+                    <div
+                      key={slot}
+                      className="flex-1 rounded-[1px]"
+                      style={{
+                        height: 12,
+                        backgroundColor: colour,
+                        opacity: 0.85,
+                      }}
+                      title={`${day} ${slotToTime(slot)}–${slotToTime(slot + 1)}`}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+
+          {/* Bottom axis labels at select positions */}
+          <div className="flex mt-1 pl-8">
+            {AXIS_TICKS.slice(0, -1).map((tick) => (
+              <div
+                key={tick}
+                className="text-[9px] text-slate-600 tabular-nums"
+                style={{ width: `${(100 / 48) * 6}%` }}
+              >
+                {slotToTime(tick)}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <PeriodLegend periods={periods} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Legacy rate window fallback (when no weeklyScheduleJson)
+// Shows horizontal bands: night / day / peak / day / night across 24h
+// ---------------------------------------------------------------------------
+
+function LegacyRateBands({ version }: { version: TariffVersionDetail }) {
+  const hasPeriods = version.pricePeriods.length > 0;
+  if (hasPeriods) return null; // shouldn't reach here, but guard
+
+  const bands = [
+    {
+      label: 'Night',
+      time: `${version.nightStartLocalTime ?? '23:00'}–${version.nightEndLocalTime ?? '08:00'}`,
+      rate: version.nightRate,
+      colour: '#3b82f6',
+    },
+    {
+      label: 'Day',
+      time: `${version.nightEndLocalTime ?? '08:00'}–${version.peakStartLocalTime ?? '17:00'}`,
+      rate: version.dayRate,
+      colour: '#f59e0b',
+    },
+    {
+      label: 'Peak',
+      time: `${version.peakStartLocalTime ?? '17:00'}–${version.peakEndLocalTime ?? '19:00'}`,
+      rate: version.peakRate,
+      colour: '#ef4444',
+    },
+    {
+      label: 'Day',
+      time: `${version.peakEndLocalTime ?? '19:00'}–${version.nightStartLocalTime ?? '23:00'}`,
+      rate: version.dayRate,
+      colour: '#f59e0b',
+    },
+  ].filter((b) => b.rate);
+
+  return (
+    <div>
+      <p className="text-xs font-medium text-slate-400 mb-2">Rate windows</p>
+      <div className="flex flex-wrap gap-2">
+        {bands.map((b, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-1.5 rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2"
+          >
+            <span
+              className="inline-block h-2 w-2 rounded-sm"
+              style={{ backgroundColor: b.colour }}
+            />
+            <div>
+              <p className="text-xs font-medium text-slate-200">{b.label}</p>
+              <p className="text-[10px] text-slate-500">{b.time}</p>
+              <p className="text-xs text-slate-300 tabular-nums">{formatRate(b.rate)}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Current tariff card
+// ---------------------------------------------------------------------------
+
+function CurrentTariffCard({
+  version,
+  supplierName,
+  planName,
+  isExportEnabled,
+}: {
+  version: TariffVersionDetail;
+  supplierName: string;
+  planName: string;
+  isExportEnabled: boolean;
+}) {
+  const hasSchedule = version.weeklyScheduleJson !== null && version.pricePeriods.length > 0;
+  const standingCharge = version.fixedCharges.find((c) => c.chargeType === 'standing_charge') ?? null;
+
+  return (
+    <div className="rounded-[20px] border border-emerald-800/30 bg-[#0d1f18] p-5 shadow-[0_8px_30px_rgba(2,6,23,0.25)]">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <CheckCircle2 size={14} className="text-emerald-400 shrink-0" />
+            <span className="text-xs font-semibold text-emerald-400 uppercase tracking-wide">
+              Active tariff
+            </span>
+          </div>
+          <h2 className="text-base font-semibold text-slate-100">{planName}</h2>
+          <p className="text-xs text-slate-400 mt-0.5">
+            {supplierName}
+            {version.versionLabel !== planName ? ` · ${version.versionLabel}` : ''}
+          </p>
+        </div>
+        <Link
+          href="#"
+          className="shrink-0 inline-flex items-center gap-1.5 rounded-full border border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-300 hover:border-slate-500 hover:text-slate-100 transition-colors"
+        >
+          Edit <ArrowRight size={10} />
+        </Link>
+      </div>
+
+      {/* Validity and meta */}
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
+        <span>
+          From <span className="text-slate-300">{formatDate(version.validFromLocalDate)}</span>
+        </span>
+        {version.validToLocalDate ? (
+          <span>
+            To <span className="text-slate-300">{formatDate(version.validToLocalDate)}</span>
+          </span>
+        ) : (
+          <span className="text-emerald-600">No end date</span>
+        )}
+        {isExportEnabled && version.exportRate && (
+          <span>
+            Export <span className="text-slate-300">{formatRate(version.exportRate)}</span>
+          </span>
+        )}
+        {standingCharge && (
+          <span>
+            Standing charge{' '}
+            <span className="text-slate-300">
+              {formatStandingCharge(standingCharge.amount, standingCharge.unit)}
+            </span>
+            {!standingCharge.vatInclusive && (
+              <span className="text-slate-600"> excl. VAT</span>
+            )}
+          </span>
+        )}
+        {version.vatRate && (
+          <span>
+            VAT <span className="text-slate-300">{(parseFloat(version.vatRate) * 100).toFixed(0)}%</span>
+          </span>
+        )}
+      </div>
+
+      {/* Schedule preview or legacy bands */}
+      <div className="mt-5 pt-4 border-t border-slate-800/60">
+        {hasSchedule ? (
+          <WeeklyScheduleGrid
+            schedule={version.weeklyScheduleJson!}
+            periods={version.pricePeriods}
+          />
+        ) : (
+          <LegacyRateBands version={version} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Version timeline
+// ---------------------------------------------------------------------------
+
+function VersionTimeline({ versions }: { versions: TariffVersionSummary[] }) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <History size={15} className="text-slate-400" />
+          <h3 className="text-sm font-semibold text-slate-200">Version history</h3>
+        </div>
+        <Link
+          href="#"
+          className="inline-flex items-center gap-1 rounded-full border border-indigo-500/40 bg-indigo-600/70 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-600 transition-colors"
+        >
+          <Plus size={11} />
+          Add version
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {versions.map((v, i) => {
+          const isCurrent = v.isActiveDefault || v.validToLocalDate === null;
+          return (
+            <div
+              key={v.id}
+              className={[
+                'relative flex items-start gap-4 rounded-2xl border px-4 py-3.5',
+                isCurrent
+                  ? 'border-emerald-800/30 bg-[#0d1f18]'
+                  : 'border-slate-800/60 bg-slate-900/40',
+              ].join(' ')}
+            >
+              {/* Timeline connector line */}
+              {i < versions.length - 1 && (
+                <div className="absolute left-[1.65rem] top-full h-2 w-px bg-slate-800" />
+              )}
+
+              <div
+                className={[
+                  'mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full border',
+                  isCurrent
+                    ? 'border-emerald-500 bg-emerald-500/40'
+                    : 'border-slate-600 bg-slate-700',
+                ].join(' ')}
+              />
+
+              <div className="flex-1 min-w-0">
+                <div className="flex items-start justify-between gap-2 flex-wrap">
+                  <div>
+                    <p
+                      className={[
+                        'text-sm font-medium',
+                        isCurrent ? 'text-slate-100' : 'text-slate-300',
+                      ].join(' ')}
+                    >
+                      {v.versionLabel}
+                    </p>
+                    <p className="text-xs text-slate-500 mt-0.5">
+                      {formatDate(v.validFromLocalDate)}
+                      {' — '}
+                      {v.validToLocalDate ? formatDate(v.validToLocalDate) : 'present'}
+                    </p>
+                  </div>
+                  {isCurrent && (
+                    <span className="shrink-0 rounded-full bg-emerald-900/50 border border-emerald-800/40 px-2 py-0.5 text-[10px] font-semibold text-emerald-400">
+                      Current
+                    </span>
+                  )}
+                </div>
+
+                {/* Key rates */}
+                <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-slate-500">
+                  {v.dayRate && (
+                    <span>Day <span className="text-slate-300">{formatRate(v.dayRate)}</span></span>
+                  )}
+                  {v.nightRate && (
+                    <span>Night <span className="text-slate-300">{formatRate(v.nightRate)}</span></span>
+                  )}
+                  {v.peakRate && (
+                    <span>Peak <span className="text-slate-300">{formatRate(v.peakRate)}</span></span>
+                  )}
+                  {v.exportRate && (
+                    <span>Export <span className="text-slate-300">{formatRate(v.exportRate)}</span></span>
+                  )}
+                </div>
+              </div>
+
+              {!isCurrent && (
+                <Link
+                  href="#"
+                  className="shrink-0 text-xs text-slate-500 hover:text-slate-300 transition-colors"
+                >
+                  View
+                </Link>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState() {
+  return (
+    <div className="mt-8 rounded-[20px] border border-dashed border-slate-700 bg-slate-900/40 px-6 py-12 text-center">
+      <Receipt size={28} className="mx-auto mb-4 text-slate-600" />
+      <p className="text-sm font-semibold text-slate-300">No tariff set up yet</p>
+      <p className="mt-2 text-xs text-slate-500 max-w-sm mx-auto leading-relaxed">
+        Add your electricity tariff to start seeing cost and savings calculations.
+        You can add multiple rate versions if your tariff has changed over time.
+      </p>
+      <Link
+        href="#"
+        className="mt-5 inline-flex items-center gap-1.5 rounded-full border border-indigo-500/50 bg-indigo-600/80 px-4 py-2 text-xs font-medium text-white hover:bg-indigo-600 transition-colors"
+      >
+        <Plus size={12} />
+        Set up tariff
+      </Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default async function TariffsPage() {
+  const data = await loadTariffOverview(SEED_INSTALLATION_ID);
+
+  const isEmpty = !data.plan || data.allVersions.length === 0;
+
+  return (
+    <div className="max-w-2xl">
+      {/* Page header */}
+      <div className="flex items-center justify-between gap-4 mb-6">
+        <div className="flex items-center gap-2">
+          <Receipt size={18} className="text-slate-400" />
+          <h1 className="text-lg font-semibold text-slate-100">Tariffs</h1>
+        </div>
+        {!isEmpty && (
+          <Link
+            href="#"
+            className="inline-flex items-center gap-1.5 rounded-full border border-indigo-500/40 bg-indigo-600/70 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-600 transition-colors"
+          >
+            <Plus size={11} />
+            Add version
+          </Link>
+        )}
+      </div>
+
+      <p className="text-sm text-slate-400 leading-relaxed max-w-prose mb-8">
         Manage your electricity tariff history — import rates, export rates, standing charges,
         and contract dates. Tariff data is required for all cost and savings calculations.
       </p>
 
-      <div className="mt-8 rounded-[20px] border border-dashed border-slate-700 bg-slate-900/40 px-6 py-10 text-center">
-        <Receipt size={28} className="mx-auto mb-4 text-slate-700" />
-        <p className="text-sm font-semibold text-slate-300">
-          Full tariff management coming in the next story
-        </p>
-        <p className="mt-2 text-xs text-slate-500 max-w-sm mx-auto">
-          You will be able to view your active tariff, manage historical versions,
-          and set contract dates here.
-        </p>
-      </div>
+      {isEmpty ? (
+        <EmptyState />
+      ) : (
+        <div className="flex flex-col gap-6">
+          {/* Contract reminder banner */}
+          {data.contract && <ContractBanner contract={data.contract} />}
+
+          {/* Current tariff */}
+          {data.activeVersion && (
+            <CurrentTariffCard
+              version={data.activeVersion}
+              supplierName={data.plan!.supplierName}
+              planName={data.plan!.planName}
+              isExportEnabled={data.plan!.isExportEnabled}
+            />
+          )}
+
+          {/* Version history */}
+          {data.allVersions.length > 0 && (
+            <VersionTimeline versions={data.allVersions} />
+          )}
+
+          {/* Info note */}
+          <div className="flex items-start gap-2.5 rounded-2xl border border-slate-800/60 bg-slate-900/30 px-4 py-3.5">
+            <Info size={13} className="mt-0.5 shrink-0 text-slate-500" />
+            <p className="text-xs text-slate-500 leading-relaxed">
+              Editing a tariff version will trigger a recalculation of all historical cost and savings
+              figures that fall within that version's date range. This may take a few moments.
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import {
   Receipt,
   Plus,
-  CalendarClock,
   AlertTriangle,
   Info,
   ArrowRight,
@@ -10,7 +9,12 @@ import {
   History,
 } from 'lucide-react';
 import { loadTariffOverview } from '@/src/tariffs/loader';
-import type { TariffVersionDetail, TariffVersionSummary, ContractInfo, PricePeriod } from '@/src/tariffs/loader';
+import type {
+  TariffVersionDetail,
+  TariffVersionSummary,
+  ContractInfo,
+  PricePeriod,
+} from '@/src/tariffs/loader';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,7 +32,8 @@ function formatDate(iso: string): string {
   }).format(new Date(iso + 'T00:00:00'));
 }
 
-function formatRate(rate: string | null): string {
+function formatRate(rate: string | null, isFree?: boolean): string {
+  if (isFree) return 'Free';
   if (!rate) return '—';
   const c = (parseFloat(rate) * 100).toFixed(2);
   return `${c}¢`;
@@ -41,7 +46,6 @@ function formatStandingCharge(amount: string, unit: string): string {
   return `€${val}`;
 }
 
-/** Days until a local date string (YYYY-MM-DD). Negative = already past. */
 function daysUntil(localDate: string): number {
   const target = new Date(localDate + 'T00:00:00');
   const now = new Date();
@@ -49,11 +53,222 @@ function daysUntil(localDate: string): number {
   return Math.ceil((target.getTime() - now.getTime()) / 86_400_000);
 }
 
-// Slot index → HH:MM label (every 3 hours for axis labels)
 function slotToTime(slot: number): string {
-  const h = Math.floor(slot / 2);
+  const h = Math.floor((slot % 48) / 2);
   const m = slot % 2 === 0 ? '00' : '30';
   return `${String(h).padStart(2, '0')}:${m}`;
+}
+
+// ---------------------------------------------------------------------------
+// Scheme derivation
+// Groups the 7 days (Mon=0 … Sun=6) by identical 48-slot pattern.
+// Returns one entry per unique pattern, sorted by first day index.
+// ---------------------------------------------------------------------------
+
+type TariffScheme = {
+  /** Day indices (0=Mon … 6=Sun) that share this pattern. */
+  days: number[];
+  /** The 48-slot pattern (period IDs). */
+  slots: string[];
+  /** Price periods that actually appear in this scheme's slots. */
+  periods: PricePeriod[];
+};
+
+function deriveSchemes(schedule: string[], allPeriods: PricePeriod[]): TariffScheme[] {
+  const periodMap = new Map(allPeriods.map((p) => [p.id, p]));
+  // Represent each day's pattern as a stable string key for grouping
+  const dayPatterns: string[] = Array.from({ length: 7 }, (_, d) =>
+    schedule.slice(d * 48, d * 48 + 48).join(','),
+  );
+
+  const seen = new Map<string, number>(); // pattern key → scheme index
+  const schemes: TariffScheme[] = [];
+
+  for (let d = 0; d < 7; d++) {
+    const key = dayPatterns[d];
+    if (seen.has(key)) {
+      schemes[seen.get(key)!].days.push(d);
+    } else {
+      const slots = schedule.slice(d * 48, d * 48 + 48);
+      const uniqueIds = [...new Set(slots)];
+      const periods = uniqueIds
+        .map((id) => periodMap.get(id))
+        .filter((p): p is PricePeriod => p !== undefined)
+        .sort((a, b) => a.sortOrder - b.sortOrder);
+      seen.set(key, schemes.length);
+      schemes.push({ days: [d], slots, periods });
+    }
+  }
+
+  return schemes;
+}
+
+// ---------------------------------------------------------------------------
+// Scheme block: day pills + one row per period with 48-slot activity bar
+// ---------------------------------------------------------------------------
+
+const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+const TIME_AXIS   = ['00:00', '03:00', '06:00', '09:00', '12:00', '15:00', '18:00', '21:00'];
+
+function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
+  const daySet = new Set(scheme.days);
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/50 px-4 py-4">
+      {/* Day pills */}
+      <div className="flex items-center gap-1.5 mb-4">
+        {DAY_LETTERS.map((letter, i) => {
+          const active = daySet.has(i);
+          return (
+            <span
+              key={i}
+              className={[
+                'inline-flex h-6 w-6 items-center justify-center rounded-full text-[11px] font-semibold tabular-nums',
+                active
+                  ? 'bg-slate-600 text-slate-100'
+                  : 'bg-slate-800/50 text-slate-600',
+              ].join(' ')}
+            >
+              {letter}
+            </span>
+          );
+        })}
+      </div>
+
+      {/* Period rows */}
+      <div className="flex flex-col gap-2.5">
+        {scheme.periods.map((period) => (
+          <div key={period.id} className="flex items-center gap-3">
+            {/* Label */}
+            <div className="w-28 sm:w-36 shrink-0 flex items-center gap-2">
+              <span
+                className="h-2.5 w-2.5 rounded-sm shrink-0"
+                style={{ backgroundColor: period.colourHex ?? '#64748b' }}
+              />
+              <span className="text-xs font-medium text-slate-300 truncate">
+                {period.periodLabel}
+              </span>
+              <span className="text-xs text-slate-500 tabular-nums shrink-0">
+                {formatRate(period.ratePerKwh, period.isFreeImport)}
+              </span>
+            </div>
+
+            {/* Activity bar — 48 slots, coloured where this period is active */}
+            <div className="flex flex-1 gap-[1.5px]">
+              {scheme.slots.map((slotPeriodId, slot) => {
+                const isActive = slotPeriodId === period.id;
+                return (
+                  <div
+                    key={slot}
+                    className="flex-1 rounded-[1.5px] md:rounded-[2px]"
+                    style={{
+                      height: 18,
+                      backgroundColor: isActive
+                        ? (period.colourHex ?? '#64748b')
+                        : '#1e293b',
+                      opacity: isActive ? 0.88 : 1,
+                    }}
+                    title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Time axis — 8 labels, each spanning 6 slots (3 hours) */}
+      <div className="flex mt-2 pl-[7.5rem] sm:pl-[9.5rem]">
+        {TIME_AXIS.map((t) => (
+          <div key={t} className="flex-1 text-[9px] text-slate-600 tabular-nums">
+            {t}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Schedule section: derives and renders all scheme blocks
+// ---------------------------------------------------------------------------
+
+function ScheduleSection({
+  version,
+}: {
+  version: TariffVersionDetail;
+}) {
+  const hasSchedule =
+    version.weeklyScheduleJson !== null && version.pricePeriods.length > 0;
+
+  if (!hasSchedule) {
+    // Legacy fallback — no schedule JSON, show rate window tiles
+    return <LegacyRateBands version={version} />;
+  }
+
+  const schemes = deriveSchemes(version.weeklyScheduleJson!, version.pricePeriods);
+
+  return (
+    <div>
+      <p className="text-xs font-medium text-slate-400 mb-3">Weekly schedule</p>
+      <div className="flex flex-col gap-3">
+        {schemes.map((scheme, i) => (
+          <TariffSchemeBlock key={i} scheme={scheme} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Legacy rate window fallback (no weeklyScheduleJson)
+// ---------------------------------------------------------------------------
+
+function LegacyRateBands({ version }: { version: TariffVersionDetail }) {
+  const bands = [
+    {
+      label: 'Night',
+      time: `${version.nightStartLocalTime ?? '23:00'}–${version.nightEndLocalTime ?? '08:00'}`,
+      rate: version.nightRate,
+      colour: '#3b82f6',
+    },
+    {
+      label: 'Day',
+      time: `${version.nightEndLocalTime ?? '08:00'}–${version.peakStartLocalTime ?? '17:00'}`,
+      rate: version.dayRate,
+      colour: '#f59e0b',
+    },
+    {
+      label: 'Peak',
+      time: `${version.peakStartLocalTime ?? '17:00'}–${version.peakEndLocalTime ?? '19:00'}`,
+      rate: version.peakRate,
+      colour: '#ef4444',
+    },
+  ].filter((b) => b.rate);
+
+  return (
+    <div>
+      <p className="text-xs font-medium text-slate-400 mb-2">Rate windows</p>
+      <div className="flex flex-wrap gap-2">
+        {bands.map((b, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-1.5 rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2"
+          >
+            <span
+              className="inline-block h-2 w-2 rounded-sm shrink-0"
+              style={{ backgroundColor: b.colour }}
+            />
+            <div>
+              <p className="text-xs font-medium text-slate-200">{b.label}</p>
+              <p className="text-[10px] text-slate-500">{b.time}</p>
+              <p className="text-xs text-slate-300 tabular-nums">{formatRate(b.rate)}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -62,11 +277,11 @@ function slotToTime(slot: number): string {
 
 function ContractBanner({ contract }: { contract: ContractInfo }) {
   const reviewDays = contract.expectedReviewDate ? daysUntil(contract.expectedReviewDate) : null;
-  const endDays = contract.contractEndDate ? daysUntil(contract.contractEndDate) : null;
+  const endDays    = contract.contractEndDate    ? daysUntil(contract.contractEndDate)    : null;
 
-  const isExpired = endDays !== null && endDays < 0;
-  const endingSoon = !isExpired && endDays !== null && endDays <= 90;
-  const reviewSoon = !isExpired && reviewDays !== null && reviewDays >= 0 && reviewDays <= 60;
+  const isExpired   = endDays !== null && endDays < 0;
+  const endingSoon  = !isExpired && endDays !== null && endDays <= 90;
+  const reviewSoon  = !isExpired && reviewDays !== null && reviewDays >= 0 && reviewDays <= 60;
 
   if (!isExpired && !endingSoon && !reviewSoon) return null;
 
@@ -76,9 +291,7 @@ function ContractBanner({ contract }: { contract: ContractInfo }) {
     <div
       className={[
         'flex items-start gap-3 rounded-2xl border px-4 py-3.5',
-        isUrgent
-          ? 'border-red-800/40 bg-red-950/30'
-          : 'border-amber-700/30 bg-amber-950/20',
+        isUrgent ? 'border-red-800/40 bg-red-950/30' : 'border-amber-700/30 bg-amber-950/20',
       ].join(' ')}
     >
       <AlertTriangle
@@ -117,176 +330,7 @@ function ContractBanner({ contract }: { contract: ContractInfo }) {
 }
 
 // ---------------------------------------------------------------------------
-// Price period legend
-// ---------------------------------------------------------------------------
-
-function PeriodLegend({ periods }: { periods: PricePeriod[] }) {
-  return (
-    <div className="flex flex-wrap gap-3">
-      {periods.map((p) => (
-        <div key={p.id} className="flex items-center gap-1.5">
-          <span
-            className="inline-block h-2.5 w-2.5 rounded-sm"
-            style={{ backgroundColor: p.colourHex ?? '#64748b' }}
-          />
-          <span className="text-xs text-slate-300">{p.periodLabel}</span>
-          <span className="text-xs text-slate-500">{formatRate(p.ratePerKwh)}</span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Weekly schedule preview (schedule-based)
-// 7 rows (Mon–Sun) × 48 columns (half-hours), each cell coloured by period
-// ---------------------------------------------------------------------------
-
-const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-// Show tick marks every 6 slots (3 hours): 00, 06, 12, 18, 24, 30, 36, 42
-const AXIS_TICKS = [0, 6, 12, 18, 24, 30, 36, 42, 48];
-
-function WeeklyScheduleGrid({
-  schedule,
-  periods,
-}: {
-  schedule: string[];
-  periods: PricePeriod[];
-}) {
-  const colourMap = new Map(periods.map((p) => [p.id, p.colourHex ?? '#64748b']));
-
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-3">
-        <span className="text-xs font-medium text-slate-400">Weekly schedule</span>
-      </div>
-
-      {/* Grid */}
-      <div className="overflow-x-auto">
-        <div style={{ minWidth: 360 }}>
-          {/* Time axis */}
-          <div className="flex mb-1 pl-8">
-            {AXIS_TICKS.map((tick) => (
-              <div
-                key={tick}
-                className="text-[9px] text-slate-600 tabular-nums"
-                style={{ width: `${(100 / 48) * (tick === 48 ? 0 : 1)}%`, flexShrink: 0 }}
-              >
-                {tick < 48 ? slotToTime(tick) : ''}
-              </div>
-            ))}
-          </div>
-
-          {/* Day rows */}
-          {DAY_LABELS.map((day, dayIdx) => (
-            <div key={day} className="flex items-center gap-1 mb-0.5">
-              <span className="w-7 shrink-0 text-[10px] text-slate-500 text-right pr-1">{day}</span>
-              <div className="flex flex-1 gap-px">
-                {Array.from({ length: 48 }, (_, slot) => {
-                  const periodId = schedule[dayIdx * 48 + slot];
-                  const colour = colourMap.get(periodId) ?? '#1e293b';
-                  return (
-                    <div
-                      key={slot}
-                      className="flex-1 rounded-[1px]"
-                      style={{
-                        height: 12,
-                        backgroundColor: colour,
-                        opacity: 0.85,
-                      }}
-                      title={`${day} ${slotToTime(slot)}–${slotToTime(slot + 1)}`}
-                    />
-                  );
-                })}
-              </div>
-            </div>
-          ))}
-
-          {/* Bottom axis labels at select positions */}
-          <div className="flex mt-1 pl-8">
-            {AXIS_TICKS.slice(0, -1).map((tick) => (
-              <div
-                key={tick}
-                className="text-[9px] text-slate-600 tabular-nums"
-                style={{ width: `${(100 / 48) * 6}%` }}
-              >
-                {slotToTime(tick)}
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-3">
-        <PeriodLegend periods={periods} />
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Legacy rate window fallback (when no weeklyScheduleJson)
-// Shows horizontal bands: night / day / peak / day / night across 24h
-// ---------------------------------------------------------------------------
-
-function LegacyRateBands({ version }: { version: TariffVersionDetail }) {
-  const hasPeriods = version.pricePeriods.length > 0;
-  if (hasPeriods) return null; // shouldn't reach here, but guard
-
-  const bands = [
-    {
-      label: 'Night',
-      time: `${version.nightStartLocalTime ?? '23:00'}–${version.nightEndLocalTime ?? '08:00'}`,
-      rate: version.nightRate,
-      colour: '#3b82f6',
-    },
-    {
-      label: 'Day',
-      time: `${version.nightEndLocalTime ?? '08:00'}–${version.peakStartLocalTime ?? '17:00'}`,
-      rate: version.dayRate,
-      colour: '#f59e0b',
-    },
-    {
-      label: 'Peak',
-      time: `${version.peakStartLocalTime ?? '17:00'}–${version.peakEndLocalTime ?? '19:00'}`,
-      rate: version.peakRate,
-      colour: '#ef4444',
-    },
-    {
-      label: 'Day',
-      time: `${version.peakEndLocalTime ?? '19:00'}–${version.nightStartLocalTime ?? '23:00'}`,
-      rate: version.dayRate,
-      colour: '#f59e0b',
-    },
-  ].filter((b) => b.rate);
-
-  return (
-    <div>
-      <p className="text-xs font-medium text-slate-400 mb-2">Rate windows</p>
-      <div className="flex flex-wrap gap-2">
-        {bands.map((b, i) => (
-          <div
-            key={i}
-            className="flex items-center gap-1.5 rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2"
-          >
-            <span
-              className="inline-block h-2 w-2 rounded-sm"
-              style={{ backgroundColor: b.colour }}
-            />
-            <div>
-              <p className="text-xs font-medium text-slate-200">{b.label}</p>
-              <p className="text-[10px] text-slate-500">{b.time}</p>
-              <p className="text-xs text-slate-300 tabular-nums">{formatRate(b.rate)}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Current tariff card
+// Active tariff card
 // ---------------------------------------------------------------------------
 
 function CurrentTariffCard({
@@ -300,8 +344,8 @@ function CurrentTariffCard({
   planName: string;
   isExportEnabled: boolean;
 }) {
-  const hasSchedule = version.weeklyScheduleJson !== null && version.pricePeriods.length > 0;
-  const standingCharge = version.fixedCharges.find((c) => c.chargeType === 'standing_charge') ?? null;
+  const standingCharge =
+    version.fixedCharges.find((c) => c.chargeType === 'standing_charge') ?? null;
 
   return (
     <div className="rounded-[20px] border border-emerald-800/30 bg-[#0d1f18] p-5 shadow-[0_8px_30px_rgba(2,6,23,0.25)]">
@@ -328,7 +372,7 @@ function CurrentTariffCard({
         </Link>
       </div>
 
-      {/* Validity and meta */}
+      {/* Meta */}
       <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
         <span>
           From <span className="text-slate-300">{formatDate(version.validFromLocalDate)}</span>
@@ -342,7 +386,7 @@ function CurrentTariffCard({
         )}
         {isExportEnabled && version.exportRate && (
           <span>
-            Export <span className="text-slate-300">{formatRate(version.exportRate)}</span>
+            Export <span className="text-slate-300 tabular-nums">{formatRate(version.exportRate)}</span>
           </span>
         )}
         {standingCharge && (
@@ -358,28 +402,24 @@ function CurrentTariffCard({
         )}
         {version.vatRate && (
           <span>
-            VAT <span className="text-slate-300">{(parseFloat(version.vatRate) * 100).toFixed(0)}%</span>
+            VAT{' '}
+            <span className="text-slate-300">
+              {(parseFloat(version.vatRate) * 100).toFixed(0)}%
+            </span>
           </span>
         )}
       </div>
 
-      {/* Schedule preview or legacy bands */}
+      {/* Schedule */}
       <div className="mt-5 pt-4 border-t border-slate-800/60">
-        {hasSchedule ? (
-          <WeeklyScheduleGrid
-            schedule={version.weeklyScheduleJson!}
-            periods={version.pricePeriods}
-          />
-        ) : (
-          <LegacyRateBands version={version} />
-        )}
+        <ScheduleSection version={version} />
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Version timeline
+// Version history timeline
 // ---------------------------------------------------------------------------
 
 function VersionTimeline({ versions }: { versions: TariffVersionSummary[] }) {
@@ -412,11 +452,9 @@ function VersionTimeline({ versions }: { versions: TariffVersionSummary[] }) {
                   : 'border-slate-800/60 bg-slate-900/40',
               ].join(' ')}
             >
-              {/* Timeline connector line */}
               {i < versions.length - 1 && (
                 <div className="absolute left-[1.65rem] top-full h-2 w-px bg-slate-800" />
               )}
-
               <div
                 className={[
                   'mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full border',
@@ -425,7 +463,6 @@ function VersionTimeline({ versions }: { versions: TariffVersionSummary[] }) {
                     : 'border-slate-600 bg-slate-700',
                 ].join(' ')}
               />
-
               <div className="flex-1 min-w-0">
                 <div className="flex items-start justify-between gap-2 flex-wrap">
                   <div>
@@ -449,24 +486,21 @@ function VersionTimeline({ versions }: { versions: TariffVersionSummary[] }) {
                     </span>
                   )}
                 </div>
-
-                {/* Key rates */}
-                <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-slate-500">
+                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-slate-500">
                   {v.dayRate && (
-                    <span>Day <span className="text-slate-300">{formatRate(v.dayRate)}</span></span>
+                    <span>Day <span className="text-slate-300 tabular-nums">{formatRate(v.dayRate)}</span></span>
                   )}
                   {v.nightRate && (
-                    <span>Night <span className="text-slate-300">{formatRate(v.nightRate)}</span></span>
+                    <span>Night <span className="text-slate-300 tabular-nums">{formatRate(v.nightRate)}</span></span>
                   )}
                   {v.peakRate && (
-                    <span>Peak <span className="text-slate-300">{formatRate(v.peakRate)}</span></span>
+                    <span>Peak <span className="text-slate-300 tabular-nums">{formatRate(v.peakRate)}</span></span>
                   )}
                   {v.exportRate && (
-                    <span>Export <span className="text-slate-300">{formatRate(v.exportRate)}</span></span>
+                    <span>Export <span className="text-slate-300 tabular-nums">{formatRate(v.exportRate)}</span></span>
                   )}
                 </div>
               </div>
-
               {!isCurrent && (
                 <Link
                   href="#"
@@ -513,12 +547,11 @@ function EmptyState() {
 
 export default async function TariffsPage() {
   const data = await loadTariffOverview(SEED_INSTALLATION_ID);
-
   const isEmpty = !data.plan || data.allVersions.length === 0;
 
   return (
-    <div className="max-w-2xl">
-      {/* Page header */}
+    <div>
+      {/* Header */}
       <div className="flex items-center justify-between gap-4 mb-6">
         <div className="flex items-center gap-2">
           <Receipt size={18} className="text-slate-400" />
@@ -544,10 +577,8 @@ export default async function TariffsPage() {
         <EmptyState />
       ) : (
         <div className="flex flex-col gap-6">
-          {/* Contract reminder banner */}
           {data.contract && <ContractBanner contract={data.contract} />}
 
-          {/* Current tariff */}
           {data.activeVersion && (
             <CurrentTariffCard
               version={data.activeVersion}
@@ -557,17 +588,16 @@ export default async function TariffsPage() {
             />
           )}
 
-          {/* Version history */}
           {data.allVersions.length > 0 && (
             <VersionTimeline versions={data.allVersions} />
           )}
 
-          {/* Info note */}
           <div className="flex items-start gap-2.5 rounded-2xl border border-slate-800/60 bg-slate-900/30 px-4 py-3.5">
             <Info size={13} className="mt-0.5 shrink-0 text-slate-500" />
             <p className="text-xs text-slate-500 leading-relaxed">
-              Editing a tariff version will trigger a recalculation of all historical cost and savings
-              figures that fall within that version's date range. This may take a few moments.
+              Editing a tariff version will trigger a recalculation of all historical cost and
+              savings figures that fall within that version's date range. This may take a few
+              moments.
             </p>
           </div>
         </div>

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -135,71 +135,78 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
         })}
       </div>
 
-      {/* Period rows */}
-      <div className="flex flex-col gap-3">
-        {scheme.periods.map((period) => (
-          <div key={period.id}>
-            {/* Label: stacks above bar on mobile, sits left of bar on desktop */}
-            <div className="flex items-center gap-2 mb-1.5 md:hidden">
-              <span
-                className="h-2.5 w-2.5 rounded-sm shrink-0"
-                style={{ backgroundColor: period.colourHex ?? '#64748b' }}
-              />
-              <span className="text-xs font-medium text-slate-300">
-                {period.periodLabel}
-              </span>
-              <span className="text-xs text-slate-500 tabular-nums">
-                {formatRate(period.ratePerKwh, period.isFreeImport)}
-              </span>
-            </div>
+      {/* Scrollable bars region — minimum width keeps slots at ~11px on mobile */}
+      <div className="overflow-x-auto -mx-4 px-4">
+        <div style={{ minWidth: 540 }}>
 
-            <div className="flex items-center gap-3">
-              {/* Desktop-only left label */}
-              <div className="hidden md:flex w-36 shrink-0 items-center gap-2">
-                <span
-                  className="h-2.5 w-2.5 rounded-sm shrink-0"
-                  style={{ backgroundColor: period.colourHex ?? '#64748b' }}
-                />
-                <span className="text-xs font-medium text-slate-300 truncate">
-                  {period.periodLabel}
-                </span>
-                <span className="text-xs text-slate-500 tabular-nums shrink-0">
-                  {formatRate(period.ratePerKwh, period.isFreeImport)}
-                </span>
-              </div>
+          {/* Period rows */}
+          <div className="flex flex-col gap-3">
+            {scheme.periods.map((period) => (
+              <div key={period.id}>
+                {/* Mobile label — above the bar */}
+                <div className="flex items-center gap-2 mb-1.5 md:hidden">
+                  <span
+                    className="h-2.5 w-2.5 rounded-sm shrink-0"
+                    style={{ backgroundColor: period.colourHex ?? '#64748b' }}
+                  />
+                  <span className="text-xs font-medium text-slate-300">
+                    {period.periodLabel}
+                  </span>
+                  <span className="text-xs text-slate-500 tabular-nums">
+                    {formatRate(period.ratePerKwh, period.isFreeImport)}
+                  </span>
+                </div>
 
-              {/* Activity bar — full width on mobile, flex-1 on desktop */}
-              <div className="flex flex-1 gap-[1.5px]">
-                {scheme.slots.map((slotPeriodId, slot) => {
-                  const isActive = slotPeriodId === period.id;
-                  return (
-                    <div
-                      key={slot}
-                      className="flex-1 rounded-[1.5px] md:rounded-[2px]"
-                      style={{
-                        height: 18,
-                        backgroundColor: isActive
-                          ? (period.colourHex ?? '#64748b')
-                          : '#1e293b',
-                        opacity: isActive ? 0.88 : 1,
-                      }}
-                      title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
+                <div className="flex items-center gap-3">
+                  {/* Desktop-only left label */}
+                  <div className="hidden md:flex w-36 shrink-0 items-center gap-2">
+                    <span
+                      className="h-2.5 w-2.5 rounded-sm shrink-0"
+                      style={{ backgroundColor: period.colourHex ?? '#64748b' }}
                     />
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
+                    <span className="text-xs font-medium text-slate-300 truncate">
+                      {period.periodLabel}
+                    </span>
+                    <span className="text-xs text-slate-500 tabular-nums shrink-0">
+                      {formatRate(period.ratePerKwh, period.isFreeImport)}
+                    </span>
+                  </div>
 
-      {/* Time axis — full width on mobile, offset by label column on desktop */}
-      <div className="flex mt-2 md:pl-[9.5rem]">
-        {TIME_AXIS.map((t) => (
-          <div key={t} className="flex-1 text-[9px] text-slate-600 tabular-nums">
-            {t}
+                  {/* Activity bar */}
+                  <div className="flex flex-1 gap-[1.5px]">
+                    {scheme.slots.map((slotPeriodId, slot) => {
+                      const isActive = slotPeriodId === period.id;
+                      return (
+                        <div
+                          key={slot}
+                          className="flex-1 rounded-[1.5px] md:rounded-[2px]"
+                          style={{
+                            height: 20,
+                            backgroundColor: isActive
+                              ? (period.colourHex ?? '#64748b')
+                              : '#1e293b',
+                            opacity: isActive ? 0.88 : 1,
+                          }}
+                          title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
-        ))}
+
+          {/* Time axis — offset by label column on desktop, flush on mobile */}
+          <div className="flex mt-2 md:pl-[9.5rem]">
+            {TIME_AXIS.map((t) => (
+              <div key={t} className="flex-1 text-[9px] text-slate-600 tabular-nums">
+                {t}
+              </div>
+            ))}
+          </div>
+
+        </div>
       </div>
     </div>
   );

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -136,49 +136,65 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
       </div>
 
       {/* Period rows */}
-      <div className="flex flex-col gap-2.5">
+      <div className="flex flex-col gap-3">
         {scheme.periods.map((period) => (
-          <div key={period.id} className="flex items-center gap-3">
-            {/* Label */}
-            <div className="w-28 sm:w-36 shrink-0 flex items-center gap-2">
+          <div key={period.id}>
+            {/* Label: stacks above bar on mobile, sits left of bar on desktop */}
+            <div className="flex items-center gap-2 mb-1.5 md:hidden">
               <span
                 className="h-2.5 w-2.5 rounded-sm shrink-0"
                 style={{ backgroundColor: period.colourHex ?? '#64748b' }}
               />
-              <span className="text-xs font-medium text-slate-300 truncate">
+              <span className="text-xs font-medium text-slate-300">
                 {period.periodLabel}
               </span>
-              <span className="text-xs text-slate-500 tabular-nums shrink-0">
+              <span className="text-xs text-slate-500 tabular-nums">
                 {formatRate(period.ratePerKwh, period.isFreeImport)}
               </span>
             </div>
 
-            {/* Activity bar — 48 slots, coloured where this period is active */}
-            <div className="flex flex-1 gap-[1.5px]">
-              {scheme.slots.map((slotPeriodId, slot) => {
-                const isActive = slotPeriodId === period.id;
-                return (
-                  <div
-                    key={slot}
-                    className="flex-1 rounded-[1.5px] md:rounded-[2px]"
-                    style={{
-                      height: 18,
-                      backgroundColor: isActive
-                        ? (period.colourHex ?? '#64748b')
-                        : '#1e293b',
-                      opacity: isActive ? 0.88 : 1,
-                    }}
-                    title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
-                  />
-                );
-              })}
+            <div className="flex items-center gap-3">
+              {/* Desktop-only left label */}
+              <div className="hidden md:flex w-36 shrink-0 items-center gap-2">
+                <span
+                  className="h-2.5 w-2.5 rounded-sm shrink-0"
+                  style={{ backgroundColor: period.colourHex ?? '#64748b' }}
+                />
+                <span className="text-xs font-medium text-slate-300 truncate">
+                  {period.periodLabel}
+                </span>
+                <span className="text-xs text-slate-500 tabular-nums shrink-0">
+                  {formatRate(period.ratePerKwh, period.isFreeImport)}
+                </span>
+              </div>
+
+              {/* Activity bar — full width on mobile, flex-1 on desktop */}
+              <div className="flex flex-1 gap-[1.5px]">
+                {scheme.slots.map((slotPeriodId, slot) => {
+                  const isActive = slotPeriodId === period.id;
+                  return (
+                    <div
+                      key={slot}
+                      className="flex-1 rounded-[1.5px] md:rounded-[2px]"
+                      style={{
+                        height: 18,
+                        backgroundColor: isActive
+                          ? (period.colourHex ?? '#64748b')
+                          : '#1e293b',
+                        opacity: isActive ? 0.88 : 1,
+                      }}
+                      title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
+                    />
+                  );
+                })}
+              </div>
             </div>
           </div>
         ))}
       </div>
 
-      {/* Time axis — 8 labels, each spanning 6 slots (3 hours) */}
-      <div className="flex mt-2 pl-[7.5rem] sm:pl-[9.5rem]">
+      {/* Time axis — full width on mobile, offset by label column on desktop */}
+      <div className="flex mt-2 md:pl-[9.5rem]">
         {TIME_AXIS.map((t) => (
           <div key={t} className="flex-1 text-[9px] text-slate-600 tabular-nums">
             {t}

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -116,17 +116,17 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/50 px-4 py-4">
       {/* Day pills */}
-      <div className="flex items-center gap-1.5 mb-4">
+      <div className="flex items-center gap-2 mb-4">
         {DAY_LETTERS.map((letter, i) => {
           const active = daySet.has(i);
           return (
             <span
               key={i}
               className={[
-                'inline-flex h-6 w-6 items-center justify-center rounded-full text-[11px] font-semibold tabular-nums',
+                'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
                 active
                   ? 'bg-slate-600 text-slate-100'
-                  : 'bg-slate-800/50 text-slate-600',
+                  : 'bg-slate-800 text-slate-600',
               ].join(' ')}
             >
               {letter}

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -115,22 +115,33 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
 
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/50 px-4 py-4">
-      {/* Day pills */}
-      <div className="flex items-center gap-2 mb-4">
+      {/* Day pills — inline styles guarantee exact 40 × 40 px circles on every device */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
         {DAY_LETTERS.map((letter, i) => {
           const active = daySet.has(i);
           return (
-            <span
+            <div
               key={i}
-              className={[
-                'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
-                active
-                  ? 'bg-slate-600 text-slate-100'
-                  : 'bg-slate-800 text-slate-600',
-              ].join(' ')}
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: '50%',
+                flexShrink: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 13,
+                fontWeight: 600,
+                lineHeight: 1,
+                userSelect: 'none',
+                backgroundColor: active ? '#475569' : '#1e293b',
+                color: active ? '#f1f5f9' : '#64748b',
+                // Inactive pills keep a faint ring so all circles read the same visual weight
+                boxShadow: active ? 'none' : 'inset 0 0 0 1.5px #334155',
+              }}
             >
               {letter}
-            </span>
+            </div>
           );
         })}
       </div>
@@ -172,25 +183,40 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                     </span>
                   </div>
 
-                  {/* Activity bar */}
-                  <div className="flex flex-1 gap-[1.5px]">
-                    {scheme.slots.map((slotPeriodId, slot) => {
-                      const isActive = slotPeriodId === period.id;
-                      return (
-                        <div
-                          key={slot}
-                          className="flex-1 rounded-[1.5px] md:rounded-[2px]"
-                          style={{
-                            height: 20,
-                            backgroundColor: isActive
-                              ? (period.colourHex ?? '#64748b')
-                              : '#1e293b',
-                            opacity: isActive ? 0.88 : 1,
-                          }}
-                          title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
-                        />
-                      );
-                    })}
+                  {/* Activity bar with 2-hour separator lines overlaid */}
+                  <div className="relative flex-1">
+                    <div className="flex gap-[1.5px]">
+                      {scheme.slots.map((slotPeriodId, slot) => {
+                        const isActive = slotPeriodId === period.id;
+                        return (
+                          <div
+                            key={slot}
+                            className="flex-1 rounded-[1.5px] md:rounded-[2px]"
+                            style={{
+                              height: 20,
+                              backgroundColor: isActive
+                                ? (period.colourHex ?? '#64748b')
+                                : '#1e293b',
+                              opacity: isActive ? 0.88 : 1,
+                            }}
+                            title={`${slotToTime(slot)}–${slotToTime(slot + 1)}`}
+                          />
+                        );
+                      })}
+                    </div>
+                    {/* Subtle vertical lines every 4 slots (every 2 hours) */}
+                    <div
+                      className="absolute inset-0 pointer-events-none"
+                      style={{
+                        backgroundImage: `repeating-linear-gradient(
+                          to right,
+                          transparent 0%,
+                          transparent calc(${(100 / 12).toFixed(4)}% - 1px),
+                          rgba(255,255,255,0.10) calc(${(100 / 12).toFixed(4)}% - 1px),
+                          rgba(255,255,255,0.10) ${(100 / 12).toFixed(4)}%
+                        )`,
+                      }}
+                    />
                   </div>
                 </div>
               </div>

--- a/apps/web/app/settings/tariffs/page.tsx
+++ b/apps/web/app/settings/tariffs/page.tsx
@@ -109,24 +109,36 @@ function deriveSchemes(schedule: string[], allPeriods: PricePeriod[]): TariffSch
 
 const DAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 const TIME_AXIS   = ['00:00', '03:00', '06:00', '09:00', '12:00', '15:00', '18:00', '21:00'];
+const SLOT_COUNT = 48;
+const MOBILE_SLOT_WIDTH = 12;
+const SLOT_GAP = 2;
+const SLOT_HEIGHT_MOBILE = 18;
+const DAY_PILL_SIZE = 42;
+
+function gridWidth(slotWidth: number): number {
+  return SLOT_COUNT * slotWidth + (SLOT_COUNT - 1) * SLOT_GAP;
+}
 
 function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
   const daySet = new Set(scheme.days);
+  const mobileWidth = gridWidth(MOBILE_SLOT_WIDTH);
 
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/50 px-4 py-4">
-      {/* Day pills — inline styles guarantee exact 40 × 40 px circles on every device */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+      {/* Day pills */}
+      <div
+        className="mb-4 grid grid-cols-7 gap-2"
+        style={{ width: DAY_PILL_SIZE * 7 + 8 * 6, maxWidth: '100%' }}
+      >
         {DAY_LETTERS.map((letter, i) => {
           const active = daySet.has(i);
           return (
             <div
               key={i}
               style={{
-                width: 40,
-                height: 40,
+                width: DAY_PILL_SIZE,
+                height: DAY_PILL_SIZE,
                 borderRadius: '50%',
-                flexShrink: 0,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -135,9 +147,9 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                 lineHeight: 1,
                 userSelect: 'none',
                 backgroundColor: active ? '#475569' : '#1e293b',
-                color: active ? '#f1f5f9' : '#64748b',
-                // Inactive pills keep a faint ring so all circles read the same visual weight
-                boxShadow: active ? 'none' : 'inset 0 0 0 1.5px #334155',
+                color: active ? '#f1f5f9' : '#94a3b8',
+                border: active ? '1.5px solid #64748b' : '1.5px solid #334155',
+                boxSizing: 'border-box',
               }}
             >
               {letter}
@@ -146,9 +158,9 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
         })}
       </div>
 
-      {/* Scrollable bars region — minimum width keeps slots at ~11px on mobile */}
+      {/* Scrollable bars region */}
       <div className="overflow-x-auto -mx-4 px-4">
-        <div style={{ minWidth: 540 }}>
+        <div style={{ minWidth: mobileWidth }}>
 
           {/* Period rows */}
           <div className="flex flex-col gap-3">
@@ -183,17 +195,24 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                     </span>
                   </div>
 
-                  {/* Activity bar with 2-hour separator lines overlaid */}
+                  {/* Activity bar with deterministic slot geometry and 2-hour markers */}
                   <div className="relative flex-1">
-                    <div className="flex gap-[1.5px]">
+                    <div
+                      className="grid"
+                      style={{
+                        gridTemplateColumns: `repeat(${SLOT_COUNT}, ${MOBILE_SLOT_WIDTH}px)`,
+                        columnGap: `${SLOT_GAP}px`,
+                        width: mobileWidth,
+                      }}
+                    >
                       {scheme.slots.map((slotPeriodId, slot) => {
                         const isActive = slotPeriodId === period.id;
                         return (
                           <div
                             key={slot}
-                            className="flex-1 rounded-[1.5px] md:rounded-[2px]"
+                            className="rounded-[2px] md:rounded-[3px]"
                             style={{
-                              height: 20,
+                              height: SLOT_HEIGHT_MOBILE,
                               backgroundColor: isActive
                                 ? (period.colourHex ?? '#64748b')
                                 : '#1e293b',
@@ -204,19 +223,17 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
                         );
                       })}
                     </div>
-                    {/* Subtle vertical lines every 4 slots (every 2 hours) */}
-                    <div
-                      className="absolute inset-0 pointer-events-none"
-                      style={{
-                        backgroundImage: `repeating-linear-gradient(
-                          to right,
-                          transparent 0%,
-                          transparent calc(${(100 / 12).toFixed(4)}% - 1px),
-                          rgba(255,255,255,0.10) calc(${(100 / 12).toFixed(4)}% - 1px),
-                          rgba(255,255,255,0.10) ${(100 / 12).toFixed(4)}%
-                        )`,
-                      }}
-                    />
+                    {Array.from({ length: 11 }).map((_, idx) => {
+                      const slotIndex = (idx + 1) * 4;
+                      const mobileLeft = slotIndex * MOBILE_SLOT_WIDTH + slotIndex * SLOT_GAP - SLOT_GAP / 2;
+                      return (
+                        <div
+                          key={idx}
+                          className="pointer-events-none absolute inset-y-0 w-px bg-white/14"
+                          style={{ left: mobileLeft }}
+                        />
+                      );
+                    })}
                   </div>
                 </div>
               </div>
@@ -224,9 +241,15 @@ function TariffSchemeBlock({ scheme }: { scheme: TariffScheme }) {
           </div>
 
           {/* Time axis — offset by label column on desktop, flush on mobile */}
-          <div className="flex mt-2 md:pl-[9.5rem]">
+          <div
+            className="mt-2 grid text-[10px] text-slate-500 tabular-nums md:pl-[9.5rem]"
+            style={{
+              gridTemplateColumns: `repeat(8, ${mobileWidth / 8}px)`,
+              width: mobileWidth,
+            }}
+          >
             {TIME_AXIS.map((t) => (
-              <div key={t} className="flex-1 text-[9px] text-slate-600 tabular-nums">
+              <div key={t}>
                 {t}
               </div>
             ))}

--- a/apps/web/src/db/seed.ts
+++ b/apps/web/src/db/seed.ts
@@ -6,7 +6,9 @@ import {
   providerConnections,
   tariffPlans,
   tariffPlanVersions,
+  tariffPricePeriods,
   tariffFixedChargeVersions,
+  installationContracts,
   dailySummaries,
 } from './schema';
 
@@ -23,6 +25,35 @@ const TARIFF_VERSION_1_ID    = '00000000-0000-0000-0000-000000000005';
 const TARIFF_VERSION_2_ID    = '00000000-0000-0000-0000-000000000006';
 const FIXED_CHARGE_V1_ID     = '00000000-0000-0000-0000-000000000007';
 const FIXED_CHARGE_V2_ID     = '00000000-0000-0000-0000-000000000008';
+const PRICE_PERIOD_DAY_ID    = '00000000-0000-0000-0000-000000000010';
+const PRICE_PERIOD_NIGHT_ID  = '00000000-0000-0000-0000-000000000011';
+const PRICE_PERIOD_PEAK_ID   = '00000000-0000-0000-0000-000000000012';
+const INSTALLATION_CONTRACT_ID = '00000000-0000-0000-0000-000000000013';
+
+// ---------------------------------------------------------------------------
+// Weekly schedule JSON for tariff version 2
+// 336 elements (7 days × 48 half-hours, Mon=0, slot 0 = 00:00–00:30)
+// Night: 23:00–08:00 → slots 46–47 + 0–15  → PRICE_PERIOD_NIGHT_ID
+// Peak:  17:00–19:00 → slots 34–37           → PRICE_PERIOD_PEAK_ID
+// Day:   everything else                     → PRICE_PERIOD_DAY_ID
+// ---------------------------------------------------------------------------
+function buildWeeklySchedule(): string[] {
+  const schedule: string[] = [];
+  for (let day = 0; day < 7; day++) {
+    for (let slot = 0; slot < 48; slot++) {
+      const isNight = slot <= 15 || slot >= 46;
+      const isPeak  = slot >= 34 && slot <= 37;
+      if (isNight) {
+        schedule.push(PRICE_PERIOD_NIGHT_ID);
+      } else if (isPeak) {
+        schedule.push(PRICE_PERIOD_PEAK_ID);
+      } else {
+        schedule.push(PRICE_PERIOD_DAY_ID);
+      }
+    }
+  }
+  return schedule;
+}
 
 // Daily summary IDs: one per seeded date
 const SUMMARY_IDS: Record<string, string> = {
@@ -282,6 +313,7 @@ async function seed() {
         peakStartLocalTime: '17:00',
         peakEndLocalTime: '19:00',
         isActiveDefault: true,
+        weeklyScheduleJson: buildWeeklySchedule(),
       },
     ]).onConflictDoUpdate({
       target: tariffPlanVersions.id,
@@ -299,6 +331,7 @@ async function seed() {
         peakStartLocalTime: sql`excluded.peak_start_local_time`,
         peakEndLocalTime: sql`excluded.peak_end_local_time`,
         isActiveDefault: sql`excluded.is_active_default`,
+        weeklyScheduleJson: sql`excluded.weekly_schedule_json`,
       },
     });
     console.log('  tariff_plan_versions: ok');
@@ -336,6 +369,67 @@ async function seed() {
       },
     });
     console.log('  tariff_fixed_charge_versions: ok');
+
+    // Price periods for the current (V2) tariff version — used by the weekly schedule
+    await tx.insert(tariffPricePeriods).values([
+      {
+        id: PRICE_PERIOD_DAY_ID,
+        tariffPlanVersionId: TARIFF_VERSION_2_ID,
+        periodLabel: 'Day',
+        ratePerKwh: '0.3865',
+        isFreeImport: false,
+        sortOrder: 0,
+        colourHex: '#f59e0b',
+      },
+      {
+        id: PRICE_PERIOD_NIGHT_ID,
+        tariffPlanVersionId: TARIFF_VERSION_2_ID,
+        periodLabel: 'Night',
+        ratePerKwh: '0.2125',
+        isFreeImport: false,
+        sortOrder: 1,
+        colourHex: '#3b82f6',
+      },
+      {
+        id: PRICE_PERIOD_PEAK_ID,
+        tariffPlanVersionId: TARIFF_VERSION_2_ID,
+        periodLabel: 'Peak',
+        ratePerKwh: '0.4340',
+        isFreeImport: false,
+        sortOrder: 2,
+        colourHex: '#ef4444',
+      },
+    ]).onConflictDoUpdate({
+      target: tariffPricePeriods.id,
+      set: {
+        periodLabel: sql`excluded.period_label`,
+        ratePerKwh: sql`excluded.rate_per_kwh`,
+        colourHex: sql`excluded.colour_hex`,
+        sortOrder: sql`excluded.sort_order`,
+      },
+    });
+    console.log('  tariff_price_periods: ok');
+
+    // Contract with upcoming review and expiry — seeds reminder state for the UI prototype
+    await tx.insert(installationContracts).values({
+      id: INSTALLATION_CONTRACT_ID,
+      installationId: INSTALLATION_ID,
+      tariffPlanId: TARIFF_PLAN_ID,
+      contractStartDate: '2025-10-10',
+      contractEndDate: '2026-06-30',
+      expectedReviewDate: '2026-06-01',
+      postContractDefaultBehavior: 'roll',
+      notes: 'Annual contract with Energia. Rates reviewed each October.',
+    }).onConflictDoUpdate({
+      target: installationContracts.id,
+      set: {
+        contractStartDate: sql`excluded.contract_start_date`,
+        contractEndDate: sql`excluded.contract_end_date`,
+        expectedReviewDate: sql`excluded.expected_review_date`,
+        notes: sql`excluded.notes`,
+      },
+    });
+    console.log('  installation_contracts: ok');
 
     const summaryRows = [...v1Days, ...v2Days].map(buildSummaryRow);
     await tx.insert(dailySummaries).values(summaryRows).onConflictDoUpdate({

--- a/apps/web/src/db/seed.ts
+++ b/apps/web/src/db/seed.ts
@@ -29,26 +29,38 @@ const PRICE_PERIOD_DAY_ID    = '00000000-0000-0000-0000-000000000010';
 const PRICE_PERIOD_NIGHT_ID  = '00000000-0000-0000-0000-000000000011';
 const PRICE_PERIOD_PEAK_ID   = '00000000-0000-0000-0000-000000000012';
 const INSTALLATION_CONTRACT_ID = '00000000-0000-0000-0000-000000000013';
+const PRICE_PERIOD_FREE_ID   = '00000000-0000-0000-0000-000000000014';
 
 // ---------------------------------------------------------------------------
 // Weekly schedule JSON for tariff version 2
 // 336 elements (7 days × 48 half-hours, Mon=0, slot 0 = 00:00–00:30)
-// Night: 23:00–08:00 → slots 46–47 + 0–15  → PRICE_PERIOD_NIGHT_ID
-// Peak:  17:00–19:00 → slots 34–37           → PRICE_PERIOD_PEAK_ID
-// Day:   everything else                     → PRICE_PERIOD_DAY_ID
+//
+// Mon–Fri + Sun (days 0–4, 6) — standard Night/Day/Peak pattern:
+//   Night: 00:00–08:00 (slots 0–15) and 23:00–00:00 (slots 46–47)
+//   Peak:  17:00–19:00 (slots 34–37)
+//   Day:   everything else
+//
+// Saturday (day 5) — free energy midday:
+//   Night: 00:00–08:00 (slots 0–15) and 23:00–00:00 (slots 46–47)
+//   Day:   08:00–10:00 (slots 16–19) and 16:00–23:00 (slots 32–45)
+//   Free:  10:00–16:00 (slots 20–31)  isFreeImport
 // ---------------------------------------------------------------------------
 function buildWeeklySchedule(): string[] {
   const schedule: string[] = [];
   for (let day = 0; day < 7; day++) {
+    const isSaturday = day === 5;
     for (let slot = 0; slot < 48; slot++) {
       const isNight = slot <= 15 || slot >= 46;
-      const isPeak  = slot >= 34 && slot <= 37;
       if (isNight) {
         schedule.push(PRICE_PERIOD_NIGHT_ID);
-      } else if (isPeak) {
-        schedule.push(PRICE_PERIOD_PEAK_ID);
+      } else if (isSaturday) {
+        // Saturday: free 10:00–16:00, day otherwise
+        const isFree = slot >= 20 && slot <= 31;
+        schedule.push(isFree ? PRICE_PERIOD_FREE_ID : PRICE_PERIOD_DAY_ID);
       } else {
-        schedule.push(PRICE_PERIOD_DAY_ID);
+        // Mon–Fri + Sun: peak 17:00–19:00, day otherwise
+        const isPeak = slot >= 34 && slot <= 37;
+        schedule.push(isPeak ? PRICE_PERIOD_PEAK_ID : PRICE_PERIOD_DAY_ID);
       }
     }
   }
@@ -398,6 +410,15 @@ async function seed() {
         isFreeImport: false,
         sortOrder: 2,
         colourHex: '#ef4444',
+      },
+      {
+        id: PRICE_PERIOD_FREE_ID,
+        tariffPlanVersionId: TARIFF_VERSION_2_ID,
+        periodLabel: 'Free',
+        ratePerKwh: '0.0000',
+        isFreeImport: true,
+        sortOrder: 3,
+        colourHex: '#22c55e',
       },
     ]).onConflictDoUpdate({
       target: tariffPricePeriods.id,

--- a/apps/web/src/tariffs/loader.ts
+++ b/apps/web/src/tariffs/loader.ts
@@ -1,0 +1,249 @@
+import { and, asc, desc, eq } from 'drizzle-orm';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PricePeriod = {
+  id: string;
+  periodLabel: string;
+  ratePerKwh: string;
+  isFreeImport: boolean;
+  sortOrder: number;
+  colourHex: string | null;
+};
+
+export type FixedCharge = {
+  id: string;
+  chargeType: string;
+  amount: string;
+  unit: string;
+  vatInclusive: boolean;
+  validFromLocalDate: string;
+  validToLocalDate: string | null;
+};
+
+export type TariffVersionDetail = {
+  id: string;
+  versionLabel: string;
+  validFromLocalDate: string;
+  validToLocalDate: string | null;
+  isActiveDefault: boolean;
+  // Schedule-based model
+  weeklyScheduleJson: string[] | null;
+  pricePeriods: PricePeriod[];
+  // Legacy window fields (fallback display when no weeklyScheduleJson)
+  dayRate: string | null;
+  nightRate: string | null;
+  peakRate: string | null;
+  exportRate: string | null;
+  vatRate: string | null;
+  nightStartLocalTime: string | null;
+  nightEndLocalTime: string | null;
+  peakStartLocalTime: string | null;
+  peakEndLocalTime: string | null;
+  fixedCharges: FixedCharge[];
+};
+
+export type TariffVersionSummary = {
+  id: string;
+  versionLabel: string;
+  validFromLocalDate: string;
+  validToLocalDate: string | null;
+  isActiveDefault: boolean;
+  dayRate: string | null;
+  nightRate: string | null;
+  peakRate: string | null;
+  exportRate: string | null;
+};
+
+export type ContractInfo = {
+  id: string;
+  contractStartDate: string | null;
+  contractEndDate: string | null;
+  expectedReviewDate: string | null;
+  postContractDefaultBehavior: string | null;
+  notes: string | null;
+};
+
+export type TariffPlanInfo = {
+  id: string;
+  supplierName: string;
+  planName: string;
+  productCode: string | null;
+  isExportEnabled: boolean;
+};
+
+export type TariffOverviewData = {
+  plan: TariffPlanInfo | null;
+  activeVersion: TariffVersionDetail | null;
+  allVersions: TariffVersionSummary[];
+  contract: ContractInfo | null;
+};
+
+// ---------------------------------------------------------------------------
+// Lazy DB deps
+// ---------------------------------------------------------------------------
+
+type DbModule = typeof import('../db/client');
+type SchemaModule = typeof import('../db/schema');
+
+let _deps: Promise<{
+  db: DbModule['db'];
+  tariffPlans: SchemaModule['tariffPlans'];
+  tariffPlanVersions: SchemaModule['tariffPlanVersions'];
+  tariffPricePeriods: SchemaModule['tariffPricePeriods'];
+  tariffFixedChargeVersions: SchemaModule['tariffFixedChargeVersions'];
+  installationContracts: SchemaModule['installationContracts'];
+}> | null = null;
+
+async function getDeps() {
+  if (!_deps) {
+    _deps = Promise.all([import('../db/client'), import('../db/schema')]).then(
+      ([client, schema]) => ({
+        db: client.db,
+        tariffPlans: schema.tariffPlans,
+        tariffPlanVersions: schema.tariffPlanVersions,
+        tariffPricePeriods: schema.tariffPricePeriods,
+        tariffFixedChargeVersions: schema.tariffFixedChargeVersions,
+        installationContracts: schema.installationContracts,
+      }),
+    );
+  }
+  return _deps;
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export async function loadTariffOverview(installationId: string): Promise<TariffOverviewData> {
+  const {
+    db,
+    tariffPlans,
+    tariffPlanVersions,
+    tariffPricePeriods,
+    tariffFixedChargeVersions,
+    installationContracts,
+  } = await getDeps();
+
+  // Fetch the tariff plan for this installation (one plan per installation for now)
+  const plan = await db
+    .select({
+      id: tariffPlans.id,
+      supplierName: tariffPlans.supplierName,
+      planName: tariffPlans.planName,
+      productCode: tariffPlans.productCode,
+      isExportEnabled: tariffPlans.isExportEnabled,
+    })
+    .from(tariffPlans)
+    .where(eq(tariffPlans.installationId, installationId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!plan) {
+    return { plan: null, activeVersion: null, allVersions: [], contract: null };
+  }
+
+  // Fetch all versions ordered newest first
+  const versions = await db
+    .select({
+      id: tariffPlanVersions.id,
+      versionLabel: tariffPlanVersions.versionLabel,
+      validFromLocalDate: tariffPlanVersions.validFromLocalDate,
+      validToLocalDate: tariffPlanVersions.validToLocalDate,
+      isActiveDefault: tariffPlanVersions.isActiveDefault,
+      weeklyScheduleJson: tariffPlanVersions.weeklyScheduleJson,
+      dayRate: tariffPlanVersions.dayRate,
+      nightRate: tariffPlanVersions.nightRate,
+      peakRate: tariffPlanVersions.peakRate,
+      exportRate: tariffPlanVersions.exportRate,
+      vatRate: tariffPlanVersions.vatRate,
+      nightStartLocalTime: tariffPlanVersions.nightStartLocalTime,
+      nightEndLocalTime: tariffPlanVersions.nightEndLocalTime,
+      peakStartLocalTime: tariffPlanVersions.peakStartLocalTime,
+      peakEndLocalTime: tariffPlanVersions.peakEndLocalTime,
+    })
+    .from(tariffPlanVersions)
+    .where(eq(tariffPlanVersions.tariffPlanId, plan.id))
+    .orderBy(desc(tariffPlanVersions.validFromLocalDate));
+
+  const activeVersionRow =
+    versions.find((v) => v.isActiveDefault) ??
+    versions.find((v) => v.validToLocalDate === null) ??
+    versions[0] ??
+    null;
+
+  let activeVersion: TariffVersionDetail | null = null;
+
+  if (activeVersionRow) {
+    const [pricePeriods, fixedCharges] = await Promise.all([
+      db
+        .select({
+          id: tariffPricePeriods.id,
+          periodLabel: tariffPricePeriods.periodLabel,
+          ratePerKwh: tariffPricePeriods.ratePerKwh,
+          isFreeImport: tariffPricePeriods.isFreeImport,
+          sortOrder: tariffPricePeriods.sortOrder,
+          colourHex: tariffPricePeriods.colourHex,
+        })
+        .from(tariffPricePeriods)
+        .where(eq(tariffPricePeriods.tariffPlanVersionId, activeVersionRow.id))
+        .orderBy(asc(tariffPricePeriods.sortOrder)),
+
+      db
+        .select({
+          id: tariffFixedChargeVersions.id,
+          chargeType: tariffFixedChargeVersions.chargeType,
+          amount: tariffFixedChargeVersions.amount,
+          unit: tariffFixedChargeVersions.unit,
+          vatInclusive: tariffFixedChargeVersions.vatInclusive,
+          validFromLocalDate: tariffFixedChargeVersions.validFromLocalDate,
+          validToLocalDate: tariffFixedChargeVersions.validToLocalDate,
+        })
+        .from(tariffFixedChargeVersions)
+        .where(eq(tariffFixedChargeVersions.tariffPlanVersionId, activeVersionRow.id))
+        .orderBy(asc(tariffFixedChargeVersions.validFromLocalDate)),
+    ]);
+
+    activeVersion = {
+      ...activeVersionRow,
+      weeklyScheduleJson: activeVersionRow.weeklyScheduleJson as string[] | null,
+      pricePeriods,
+      fixedCharges,
+    };
+  }
+
+  const allVersions: TariffVersionSummary[] = versions.map((v) => ({
+    id: v.id,
+    versionLabel: v.versionLabel,
+    validFromLocalDate: v.validFromLocalDate,
+    validToLocalDate: v.validToLocalDate,
+    isActiveDefault: v.isActiveDefault,
+    dayRate: v.dayRate,
+    nightRate: v.nightRate,
+    peakRate: v.peakRate,
+    exportRate: v.exportRate,
+  }));
+
+  const contract = await db
+    .select({
+      id: installationContracts.id,
+      contractStartDate: installationContracts.contractStartDate,
+      contractEndDate: installationContracts.contractEndDate,
+      expectedReviewDate: installationContracts.expectedReviewDate,
+      postContractDefaultBehavior: installationContracts.postContractDefaultBehavior,
+      notes: installationContracts.notes,
+    })
+    .from(installationContracts)
+    .where(
+      and(
+        eq(installationContracts.installationId, installationId),
+        eq(installationContracts.tariffPlanId, plan.id),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  return { plan, activeVersion, allVersions, contract };
+}

--- a/docs/features/FE-008.md
+++ b/docs/features/FE-008.md
@@ -45,7 +45,7 @@ Stories in intended execution order:
 1. ✅ [`U-049`](../stories/complete/U-049.md) Define Settings shell and setup-completion home
 2. ✅ [`P-041`](../stories/complete/P-041.md) Build Settings shell and setup-completion home
 3. ✅ [`P-044`](../stories/complete/P-044.md) Adopt schedule-based tariff schema and billing support
-4. [`U-027`](../stories/todo/U-027.md) Build polished clickable prototype for the Tariffs overview screen
+4. ✅ [`U-027`](../stories/complete/U-027.md) Build polished clickable prototype for the Tariffs overview screen
 5. [`P-042`](../stories/todo/P-042.md) Build Tariffs overview screen
 6. [`U-013`](../stories/todo/U-013.md) Add tariff-validity and contract reminders
 7. [`U-028`](../stories/todo/U-028.md) Build polished clickable prototype for schedule-based tariff editing and reminders

--- a/docs/stories/complete/U-027.md
+++ b/docs/stories/complete/U-027.md
@@ -50,4 +50,4 @@ active weekly schedule easy to understand at a glance.
 - This should feel like a trustworthy product surface, not an internal tariff
   admin table
 
-### Status: Planned
+### Status: Complete


### PR DESCRIPTION
## Summary

- Replaces the stub `/settings/tariffs` page with a full Tariffs overview: current tariff card with weekly schedule grid, version history timeline, and contract reminder banner
- Adds `src/tariffs/loader.ts` — a server-side loader that fetches the active tariff version (with price periods, fixed charges, and weekly schedule JSON), all version history, and contract data
- Extends `seed.ts` with Day/Night/Peak price periods (with hex colours), a 336-element `weeklyScheduleJson` derived from the existing night/peak window times, and a sample `installation_contracts` row with an upcoming review date

## What the page shows

**Current tariff card** — supplier, plan name, version label, validity dates, export rate, standing charge, VAT. Renders a 7-day × 48-slot colour grid when `weeklyScheduleJson` is present; falls back to labelled time-band tiles for legacy versions.

**Version timeline** — all tariff versions listed newest-first with date ranges and key rates. Current version is highlighted with an emerald dot and "Current" badge.

**Contract reminder banner** — amber nudge when review date is ≤ 60 days away; amber/red warning when contract end is ≤ 90/30 days away. Hidden when no contract exists or dates are comfortably in the future.

**Empty state** — displayed when no tariff plan is configured at all.

**Desktop and mobile** — constrained `max-w-2xl` column layout; the schedule grid scrolls horizontally on narrow screens.

## Test plan

- [ ] Visit `/settings/tariffs` while signed in — current tariff card renders with weekly colour grid and period legend
- [ ] Contract reminder banner is visible (seed contract ends 2026-06-30, review 2026-06-01)
- [ ] Version timeline shows V2 (current) and V1 (historical) with correct dates and rates
- [ ] `npm run build` passes cleanly
- [ ] `npm run db:seed` is idempotent (re-running produces no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)